### PR TITLE
Qt bug fix - update to version 1.2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - 作者: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.16`
+- Latest Version: `1.3.0`
 - License: BSD 3-Clause License
 
 `qteasy`是为量化交易人员开发的一套量化交易工具包，特点如下：

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - 作者: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.15`
+- Latest Version: `1.2.16`
 - License: BSD 3-Clause License
 
 `qteasy`是为量化交易人员开发的一套量化交易工具包，特点如下：

--- a/README_EN.md
+++ b/README_EN.md
@@ -48,7 +48,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.16`
+- Latest Version: `1.3.0`
 - License: BSD 3-Clause License
 
 `qteasy` is a quantitative trading utility package for quantitative traders, with the following features:

--- a/README_EN.md
+++ b/README_EN.md
@@ -48,7 +48,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.15`
+- Latest Version: `1.2.16`
 - License: BSD 3-Clause License
 
 `qteasy` is a quantitative trading utility package for quantitative traders, with the following features:

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -1,5 +1,16 @@
 # RELEASE HISTORY
 
+## 1.2.16 (2024-08-02)
+- New Feature: Runing example strategy files with parameter -r can now remove orders only for designated account, instead of all accounts
+- Optimized live trade log:
+  - Now delivery records for selling stocks are also displayed in a new line
+  - Fixed a bug that may cause wrong stock or cash change in trade logs
+  - Fixed a bug that causes buying orders not being delivered properly
+- Fixed a bug that sometimes empty data will be extracted even with valid data id from system datasource tables
+- Fixed a few bugs that will lead to error in CLI command `CHANGE`:
+  - Prevented from acquiring latest price when only cash is to be changed
+  - Ensured symbol be given when changing quantity of a stock
+
 ## 1.2.15 (2024-07-28)
 - Added new built-in strategies: `ATR` and `OBV`, with docstrings
 

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -1,15 +1,17 @@
 # RELEASE HISTORY
 
-## 1.2.16 (2024-08-02)
-- New Feature: Runing example strategy files with parameter -r can now remove orders only for designated account, instead of all accounts
-- Optimized live trade log:
-  - Now delivery records for selling stocks are also displayed in a new line
+## 1.3.0 (2024-08-09)
+- New Feature:
+  - Running example strategy files with parameter -r can now remove orders only for designated account, instead of all accounts
+- Improvements and bug fixes:
+  - Improved live trade log, Now delivery records for selling stocks are also displayed in a new line
+  - Now delivery records are clearer shown
   - Fixed a bug that may cause wrong stock or cash change in trade logs
-  - Fixed a bug that causes buying orders not being delivered properly
-- Fixed a bug that sometimes empty data will be extracted even with valid data id from system datasource tables
-- Fixed a few bugs that will lead to error in CLI command `CHANGE`:
-  - Prevented from acquiring latest price when only cash is to be changed
-  - Ensured symbol be given when changing quantity of a stock
+  - Fixed a bug that causes buying results not being delivered properly
+  - Fixed a bug that sometimes empty data will be extracted even with valid data id from system datasource tables
+  - Fixed a few bugs that will lead to error in CLI command `CHANGE`:
+    - Prevented from acquiring latest price when only cash is to be changed
+    - Ensured symbol be given when changing quantity of a stock
 
 ## 1.2.15 (2024-07-28)
 - Added new built-in strategies: `ATR` and `OBV`, with docstrings

--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -4,5 +4,5 @@
 - Author: **Jackie PENG**
 - Email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.16`
+- Latest Version: `1.3.0`
 - License: BSD 3-Clause

--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -4,5 +4,5 @@
 - Author: **Jackie PENG**
 - Email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.15`
+- Latest Version: `1.2.16`
 - License: BSD 3-Clause

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,8 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'qteasy'
 copyright = '2023, Jackie PENG'
 author = 'Jackie PENG'
-release = '1.2'
-version = '1.2.16'
+release = '1.3'
+version = '1.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ project = 'qteasy'
 copyright = '2023, Jackie PENG'
 author = 'Jackie PENG'
 release = '1.2'
-version = '1.2.15'
+version = '1.2.16'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.15`
+- Latest Version: `1.2.16`
 - License: BSD 3-Clause
 
 Introduction

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.2.16`
+- Latest Version: `1.3.0`
 - License: BSD 3-Clause
 
 Introduction

--- a/examples/live_daily.py
+++ b/examples/live_daily.py
@@ -55,6 +55,12 @@ if __name__ == '__main__':
 
     asset_pool = qt.filter_stock_codes(industry='家用电器, 汽车整车, 汽车服务, 酒店餐饮', exchange='SSE, SZSE')
 
+    datasource = qt.QT_DATA_SOURCE
+    if args.restart:
+        # clean up all trade data in current account
+        from qteasy.trade_recording import delete_account
+        delete_account(account_id=args.account, data_source=datasource, keep_account_id=True)
+
     qt.configure(
             mode=0,
             time_zone='Asia/Shanghai',
@@ -73,12 +79,5 @@ if __name__ == '__main__':
             live_trade_ui_type=args.ui,
             watched_price_refresh_interval=10,
     )
-    datasource = qt.QT_DATA_SOURCE
-
-    if args.restart:
-        # clean up all account data in datasource
-        for table in ['sys_op_live_accounts', 'sys_op_positions', 'sys_op_trade_orders', 'sys_op_trade_results']:
-            if datasource.table_data_exists(table):
-                datasource.drop_table_data(table)
 
     op.run()

--- a/examples/live_example.py
+++ b/examples/live_example.py
@@ -43,6 +43,12 @@ if __name__ == '__main__':
 
     asset_pool = ['000651.SZ', '688609.SH', '000550.SZ', '301215.SZ', '002676.SZ', '603726.SH']
 
+    datasource = qt.QT_DATA_SOURCE
+    if args.restart:
+        # clean up all trade data in current account
+        from qteasy.trade_recording import delete_account
+        delete_account(account_id=args.account, data_source=datasource, keep_account_id=True)
+
     qt.configure(
             mode=0,
             time_zone='Asia/Shanghai',
@@ -60,12 +66,5 @@ if __name__ == '__main__':
             live_trade_ui_type=args.ui,
             live_trade_broker_params=None,
     )
-    datasource = qt.QT_DATA_SOURCE
-
-    if args.restart:
-        # clean up all account data in datasource
-        for table in ['sys_op_live_accounts', 'sys_op_positions', 'sys_op_trade_orders', 'sys_op_trade_results']:
-            if datasource.table_data_exists(table):
-                datasource.drop_table_data(table)
 
     op.run()

--- a/examples/live_grid.py
+++ b/examples/live_grid.py
@@ -78,6 +78,12 @@ if __name__ == '__main__':
 
     op = Operator(alpha, signal_type='VS', op_type='step')
 
+    datasource = qt.QT_DATA_SOURCE
+    if args.restart:
+        # clean up all trade data in current account
+        from qteasy.trade_recording import delete_account
+        delete_account(account_id=args.account, data_source=datasource, keep_account_id=True)
+
     qt.configure(
             mode=0,
             time_zone='Asia/Shanghai',
@@ -95,13 +101,5 @@ if __name__ == '__main__':
             live_trade_ui_type=args.ui,
             watched_price_refresh_interval=30,
     )
-
-    datasource = qt.QT_DATA_SOURCE
-
-    if args.restart:
-        # clean up all account data in datasource
-        for table in ['sys_op_live_accounts', 'sys_op_positions', 'sys_op_trade_orders', 'sys_op_trade_results']:
-            if datasource.table_data_exists(table):
-                datasource.drop_table_data(table)
 
     op.run()

--- a/examples/live_grid_multi.py
+++ b/examples/live_grid_multi.py
@@ -70,9 +70,9 @@ if __name__ == '__main__':
     parser = get_qt_argparser()
     args = parser.parse_args()
     alpha = MultiGridTrade(
-            pars={'000651.SZ': (0.3, 500, 40.3),
-                  '600036.SH': (0.3, 600, 32.8),
-                  '601398.SH': (0.1, 1000, 5.4)},  # 当基准网格为0时，代表首次运行，此时买入20000股，并设置当前价为基准网格
+            pars={'000651.SZ': (0.3, 500, 0),
+                  '600036.SH': (0.3, 600, 0),
+                  '601398.SH': (0.1, 1000, 0)},  # 当基准网格为0时，代表首次运行，此时买入20000股，并设置当前价为基准网格
             par_count=3,
             par_types=['float', 'int', 'float'],
             par_range=[(0.1, 2), (100, 3000), (0, 400)],
@@ -83,6 +83,12 @@ if __name__ == '__main__':
             data_freq='5min',
             window_length=10,
     )
+    datasource = qt.QT_DATA_SOURCE
+
+    if args.restart:
+        # clean up all trade data in current account
+        from qteasy.trade_recording import delete_account
+        delete_account(account_id=args.account, data_source=datasource, keep_account_id=True)
 
     op = Operator(alpha, signal_type='VS', op_type='step')
     qt.configure(
@@ -102,12 +108,5 @@ if __name__ == '__main__':
             live_trade_ui_type=args.ui,
             watched_price_refresh_interval=30,
     )
-    datasource = qt.QT_DATA_SOURCE
-
-    if args.restart:
-        # clean up all account data in datasource
-        for table in ['sys_op_live_accounts', 'sys_op_positions', 'sys_op_trade_orders', 'sys_op_trade_results']:
-            if datasource.table_data_exists(table):
-                datasource.drop_table_data(table)
 
     op.run()

--- a/examples/live_rolling.py
+++ b/examples/live_rolling.py
@@ -47,6 +47,12 @@ if __name__ == '__main__':
         '512000.SH',  # 券商ETF
     ]
 
+    datasource = qt.QT_DATA_SOURCE
+    if args.restart:
+        # clean up all trade data in current account
+        from qteasy.trade_recording import delete_account
+        delete_account(account_id=args.account, data_source=datasource, keep_account_id=True)
+
     qt.configure(
             mode=0,
             time_zone='Asia/Shanghai',
@@ -62,13 +68,5 @@ if __name__ == '__main__':
             live_trade_ui_type=args.ui,
             live_trade_broker_params=None,
     )
-    datasource = qt.QT_DATA_SOURCE
-
-    if args.restart:
-        # TODO: clean up only selected account data
-        # clean up all account data in datasource
-        for table in ['sys_op_live_accounts', 'sys_op_positions', 'sys_op_trade_orders', 'sys_op_trade_results']:
-            if datasource.table_data_exists(table):
-                datasource.drop_table_data(table)
 
     op.run()

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: "qteasy"
-  version: "1.2.16"
+  version: "1.3.0"
 
 source:
-  git_rev: v1.2.16
+  git_rev: v1.3.0
   git_url: https://github.com/shepherdpp/qteasy
 
 requirements:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: "qteasy"
-  version: "1.2.15"
+  version: "1.2.16"
 
 source:
-  git_rev: v1.2.15
+  git_rev: v1.2.16
   git_url: https://github.com/shepherdpp/qteasy
 
 requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qteasy"
-version = "1.2.15"
+version = "1.2.16"
 authors = [
   {name="jackie PENG", email="jackie.pengzhao@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qteasy"
-version = "1.2.16"
+version = "1.3.0"
 authors = [
   {name="jackie PENG", email="jackie.pengzhao@gmail.com" },
 ]
@@ -28,7 +28,7 @@ maintainers = [
 description = "A fast quantitative investment tool kit"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.6, <3.13"
+requires-python = ">=3.7, <3.13"
 keywords = ["quantitative investment", "quantitative trading", "stock", "finance", "investment"]
 dependencies = [
     "pandas>=1.1.0",

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -39,15 +39,15 @@ from .trade_recording import delete_account
 
 
 # qteasy版本信息
-__version__ = '1.2.16'
+__version__ = '1.3.0'
 version_info = Namespace(
         major=1,
-        minor=2,
-        patch=16,
-        short=(1, 2),
-        full=(1, 2, 16),
-        string='1.2.16',
-        tuple=('1', '2', '16'),
+        minor=3,
+        patch=0,
+        short=(1, 3),
+        full=(1, 3, 0),
+        string='1.3.0',
+        tuple=('1', '3', '0'),
         releaselevel='beta',
 )
 

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -35,6 +35,7 @@ from .visual import candle
 from .finance import CashPlan, set_cost, update_cost
 from .database import DataSource, find_history_data
 from ._arg_validators import QT_CONFIG, ConfigDict
+from .trade_recording import delete_account
 
 
 # qteasy版本信息
@@ -205,5 +206,5 @@ __all__ = [
     'QT_DATA_SOURCE', 'QT_CONFIG_FILE_INTRO',
     'utilfuncs',
     'QT_CONFIG', 'ConfigDict', '__version__', 'version_info',
-    'logger_core', 'live_trade_accounts',
+    'logger_core', 'live_trade_accounts', 'delete_account',
 ]

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -39,15 +39,15 @@ from .trade_recording import delete_account
 
 
 # qteasy版本信息
-__version__ = '1.2.15'
+__version__ = '1.2.16'
 version_info = Namespace(
         major=1,
         minor=2,
-        patch=15,
+        patch=16,
         short=(1, 2),
-        full=(1, 2, 15),
-        string='1.2.15',
-        tuple=('1', '2', '15'),
+        full=(1, 2, 16),
+        string='1.2.16',
+        tuple=('1', '2', '16'),
         releaselevel='beta',
 )
 

--- a/qteasy/database.py
+++ b/qteasy/database.py
@@ -4304,20 +4304,19 @@ class DataSource:
     def read_sys_table_data(self, table, **kwargs) -> pd.DataFrame:
         """读取系统操作表的数据，包括读取所有记录，以及根据给定的条件读取记录
 
-        每次读取的数据都以行为单位，必须读取整行数据，不允许读取个别列，
-        如果给出id，只返回id行记录（dict），如果不给出id，返回所有记录（DataFrame）
+        返回的数据类型为pd.DataFrame，如果给出kwargs，返回根据条件筛选后的数据
 
         Parameters
         ----------
         table: str
             需要读取的数据表名称
         kwargs: dict
-            筛选数据的条件，包括用作筛选条件的字典如: account_id = 123
+            筛选数据的条件，包括用作筛选条件的字典如: {account_id = 123}
 
         Returns
         -------
         pd.DataFrame:
-            当不给出record_id时，读取的数据为DataFrame，包括数据表的结构化信息以及数据表中的记录
+            返回的数据为DataFrame，如果给出kwargs，返回的数据仅包括筛选后的数据
         """
 
         ensure_sys_table(table)

--- a/qteasy/database.py
+++ b/qteasy/database.py
@@ -4377,7 +4377,7 @@ class DataSource:
         if data.empty:
             return {}
 
-        if record_id > len(data):
+        if record_id not in data.index:
             return {}
 
         return data.loc[record_id].to_dict()

--- a/qteasy/emfuncs.py
+++ b/qteasy/emfuncs.py
@@ -277,7 +277,7 @@ def stock_live_kline_price(symbols, freq='D', verbose=False, parallel=True, time
                 except TimeoutError:
                     continue
                 except Exception as exc:
-                    print(f'{exc} generated an exception: {exc}')
+                    print(f'Encountered an exception: {exc}')
                 else:
                     if df.empty:
                         continue

--- a/qteasy/trade_recording.py
+++ b/qteasy/trade_recording.py
@@ -918,7 +918,7 @@ def query_trade_orders(account_id,
                        direction=None,
                        order_type=None,
                        status=None,
-                       data_source=None):
+                       data_source=None) -> pd.DataFrame:
     """ 根据symbol、direction、status 从数据库中查询交易信号并批量返回结果
 
     Parameters

--- a/qteasy/trade_recording.py
+++ b/qteasy/trade_recording.py
@@ -225,7 +225,7 @@ def update_account_balance(account_id, data_source=None, **cash_change) -> None:
     )
 
 
-def delete_account(account_id: int, data_source=None) -> None:
+def delete_account(account_id: int, data_source=None, keep_account_id=True) -> None:
     """ 删除账户，删除账户时，需要同时删除账户的持仓和交易信号。如果账户不存在，则直接返回None
     在删除账户时，同时删除账户的持仓和交易信号，如果删除账户的持仓或交易信号失败，则会回滚删除操作
 
@@ -235,6 +235,8 @@ def delete_account(account_id: int, data_source=None) -> None:
         账户的id
     data_source: DataSource, optional
         进行操作的数据源, 默认为None, 表示使用默认的数据源
+    keep_account_id: bool, optional, default True
+        是否保留account_id, 如果为False, 则删除account_id, 该id不再使用，如果为True, 则保留account_id
 
     Returns
     -------
@@ -276,8 +278,18 @@ def delete_account(account_id: int, data_source=None) -> None:
           f'orders: {order_ids}\n'
           f'results: {result_ids}')
     try:
-        # 删除账户
-        data_source.delete_sys_table_data('sys_op_live_accounts', record_ids=[account_id])
+        if not keep_account_id:
+            # 删除账户
+            data_source.delete_sys_table_data('sys_op_live_accounts', record_ids=[account_id])
+        else:
+            # 保留账户，但是删除账户的持仓并重置创建日期
+            refreshed_data = {'created_time': pd.to_datetime('today').strftime('%Y-%m-%d %H:%M:%S'),
+                              'cash_amount': 0,
+                              'available_cash': 0,
+                              'total_invest': 0,}
+            data_source.update_sys_table_data('sys_op_live_accounts',
+                                              record_id=account_id,
+                                              **refreshed_data)
         # 删除持仓
         data_source.delete_sys_table_data('sys_op_positions', record_ids=pos_ids)
         # 删除交易信号
@@ -971,8 +983,10 @@ def query_trade_orders(account_id,
 
 
 # 2 2nd level functions for trade signal TODO: (maybe) move to trading_util.py
-def read_trade_order_detail(order_id, data_source=None):
-    """ 从数据库中读取交易信号的详细信息，包括从关联表中读取symbol和position的信息
+def read_trade_order_detail(order_id, data_source=None) -> dict:
+    """ 从数据库中读取交易信号的详细信息，除了trade_order表中已有的信息以外，
+     返回值还包括从关联表中读取的信息，包括三个字段：
+     account_id, symbol, position
 
     Parameters
     ----------
@@ -983,19 +997,20 @@ def read_trade_order_detail(order_id, data_source=None):
 
     Returns
     -------
-    trade_signal_detail: dict
+    trade_order_detail: dict
         包含symbol和position信息的交易信号明细:
         {
-            'account_id': int,
-            'pos_id': int,
-            'symbol': str,
-            'position': str,
-            'direction': str,
-            'order_type': str,
-            'qty': float,
-            'price': float,
-            'status': str,
-            'submitted_time': str,
+            'order_id': int, 订单ID
+            'account_id': int,  账户ID
+            'pos_id': int,  持仓ID
+            'symbol': str,  持仓股票代码
+            'position': str,  多头/空头
+            'direction': str,  买入/卖出
+            'order_type': str,  订单类型
+            'qty': float,  挂单数量
+            'price': float,  挂单价格
+            'submitted_time': str,  订单提交时间
+            'status': str,  订单状态
         }
     """
 
@@ -1006,19 +1021,20 @@ def read_trade_order_detail(order_id, data_source=None):
         err = TypeError(f'data_source must be a DataSource instance, got {type(data_source)} instead')
         raise err
 
-    trade_signal_detail = read_trade_order(order_id, data_source=data_source)
-    if trade_signal_detail == {}:
+    trade_order_detail = read_trade_order(order_id, data_source=data_source)
+    if trade_order_detail == {}:
         return None
-    pos_id = trade_signal_detail['pos_id']
+    pos_id = trade_order_detail['pos_id']
     position = get_position_by_id(pos_id, data_source=data_source)
     if position is None:
         err = RuntimeError(f'Position (position_id = {pos_id}) not found!')
         raise err
     # 从关联表中读取symbol和position的信，添加到trade_signal_detail中
-    trade_signal_detail['account_id'] = position['account_id']
-    trade_signal_detail['symbol'] = position['symbol']
-    trade_signal_detail['position'] = position['position']
-    return trade_signal_detail
+    trade_order_detail['order_id'] = order_id
+    trade_order_detail['account_id'] = position['account_id']
+    trade_order_detail['symbol'] = position['symbol']
+    trade_order_detail['position'] = position['position']
+    return trade_order_detail
 
 
 def save_parsed_trade_orders(account_id, symbols, positions, directions, quantities, prices, data_source=None):

--- a/qteasy/trade_recording.py
+++ b/qteasy/trade_recording.py
@@ -1314,7 +1314,7 @@ def read_trade_results_by_order_id(order_id, data_source=None):
     return trade_results
 
 
-def read_trade_results_by_delivery_status(delivery_status, data_source=None):
+def read_trade_results_by_delivery_status(delivery_status, data_source=None) -> pd.DataFrame:
     """ 根据delivery_status从数据库中读取所有与signal相关的交易结果，以DataFrame的形式返回
 
     Parameters

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -1261,7 +1261,7 @@ class Trader(object):
         if not isinstance(cash_change_detail, dict):
             raise TypeError(f'cash_change_detail should be a dict, got {type(cash_change_detail)} instead.')
         # 补充金额变动的额外信息
-        cash_change_detail['reason'] = 'manual_change'
+        cash_change_detail['reason'] = 'manual'
         self.write_log_file(**cash_change_detail)
         # 发送消息通知现金变动并记录system log
         cash, available, investment = self.account_cash
@@ -2086,6 +2086,12 @@ class Trader(object):
         """
 
         from qteasy.trade_recording import get_or_create_position, get_position_by_id, update_position, get_position_ids
+        from qteasy.utilfuncs import is_complete_cn_stock_symbol_like
+
+        if not is_complete_cn_stock_symbol_like(symbol):
+            self.send_message(f'Invalid symbol: {symbol}, please check your input.'
+                              f'the symbol should include suffix like "SH"/"SZ", etc.')
+            return
 
         position_ids = get_position_ids(
                 account_id=self.account_id,

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -998,7 +998,8 @@ class Trader(object):
 
         return lines
 
-    def submit_trade_order(self, symbol: str, position: str, direction: str, order_type: str, qty: int, price: float) -> dict:
+    def submit_trade_order(self, symbol: str, position: str, direction: str,
+                           order_type: str, qty: int, price: float) -> dict:
         """ 提交订单
 
         Parameters

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -1619,15 +1619,15 @@ class Trader(object):
         )
 
         # 检查账户中的成交结果，完成全部交易结果的交割
-        delivery_result = process_account_delivery(
+        delivery_results = process_account_delivery(
                 account_id=self.account_id,
                 data_source=self._datasource,
                 config=self._config,
         )
 
         # 生成交割结果信息推送到信息队列
-        for res in delivery_result:
-            if res['deliver_status'] is None:
+        for res in delivery_results:
+            if res.get('deliver_status') is None:
                 continue
 
             self.log_cash_delivery(res)

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -1115,7 +1115,7 @@ class Trader(object):
         self.write_log_file(**trade_log)
         # 生成system_log 现金及持仓变动记录
         if qty_change != 0.:
-            self.send_message(f'<RESULT>: position {symbol}({pos}) changed: '
+            self.send_message(f'<RESULT RECORDED {order_id}>: position {symbol}({pos}) changed: '
                               f'own qyt: {qty - qty_change:.2f}->{qty:.2f}; '
                               f'available qyt: {available_qty - full_trade_result["available_qty_change"]:.2f}'
                               f'->{available_qty:.2f}; '
@@ -1177,7 +1177,7 @@ class Trader(object):
         }
         self.write_log_file(**trade_log)
         # 发送system log信息
-        self.send_message(f'<DELIVERED {order_id}>: <{account_name}-{self.account_id}> available cash:'
+        self.send_message(f'<RESULT DELIVERED {order_id}>: <{account_name}-{self.account_id}> available cash:'
                           f'[{color_tag}]¥{prev_amount}->¥{updated_amount}[/{color_tag}]')
 
     def log_qty_delivery(self, delivery_result) -> None:
@@ -1232,7 +1232,7 @@ class Trader(object):
         }
         self.write_log_file(**trade_log)
         # 发送system log信息
-        self.send_message(f'<DELIVERED {order_id}>: <{name}-{symbol}@{pos_type} side> available qty:'
+        self.send_message(f'<RESULT DELIVERED {order_id}>: <{name}-{symbol}@{pos_type} side> available qty:'
                           f'[{color_tag}]{prev_qty}->{updated_qty} [/{color_tag}]')
 
     def log_manual_cash_change(self, cash_change_detail) -> None:
@@ -1261,7 +1261,7 @@ class Trader(object):
         self.write_log_file(**cash_change_detail)
         # 发送消息通知现金变动并记录system log
         cash, available, investment = self.account_cash
-        self.send_message(f'Cash changed, now cash: {cash:.2f}, '
+        self.send_message(f'<MANUAL CHANGED CASH>: {cash:.2f}, '
                           f'available: {available:.2f}, '
                           f'total invest: {investment:.2f}')
 
@@ -1314,7 +1314,7 @@ class Trader(object):
         }
         self.write_log_file(**log_content)
         # 发送消息通知持仓变动并记录system log
-        self.send_message(f'Changed position {symbol}/{position["position"]}: '
+        self.send_message(f'<MANUAL CHANGED pos {symbol}/{position["position"]}>: '
                           f'qty: {qty - qty_change} -> {qty} '
                           f'available: {available - available_change} -> {available} '
                           f'cost: {cost - cost_change:.2f} -> {cost:.2f}')

--- a/qteasy/trader_cli.py
+++ b/qteasy/trader_cli.py
@@ -1721,7 +1721,7 @@ class TraderShell(Cmd):
             return False
 
         # get current price if price is not given
-        if price == 0:
+        if price == 0 and symbol != '':
             try:
                 freq = self.trader.operator.op_data_freq
                 last_available_data = self.trader.datasource.get_history_data(
@@ -1733,13 +1733,13 @@ class TraderShell(Cmd):
                 )
                 current_price = last_available_data['close'][symbol][-1]
             except Exception as e:
-                print(f'Error: {e}, latest available data can not be downloaded. 10.00 will be used as current price.')
+                print(f'Error: {e}, latest price not available at the moment. 10.00 will be used as current price.')
                 import traceback
                 traceback.print_exc()
                 current_price = 10.00
             price = current_price
 
-        if qty != 0:
+        if qty != 0 and symbol != '':
             if side in ['s', 'short']:
                 side = 'short'
             if side in ['l', 'long']:

--- a/qteasy/trading_util.py
+++ b/qteasy/trading_util.py
@@ -1190,7 +1190,7 @@ def calculate_cost_change(prev_qty, prev_unit_cost, qty_change, price, transacti
     else:
         additional_cost = qty_change * price + transaction_fee
         new_cost = (prev_cost + additional_cost) / (prev_qty + qty_change)
-    return new_cost - prev_cost, new_cost
+    return new_cost - prev_unit_cost, new_cost
 
 
 def get_last_trade_result_summary(account_id, shares=None, data_source=None):

--- a/qteasy/trading_util.py
+++ b/qteasy/trading_util.py
@@ -645,7 +645,7 @@ def output_trade_order():
     pass
 
 
-def submit_order(order_id, data_source=None):
+def submit_order(order_id, data_source):
     """ 将交易订单提交给交易平台或用户以等待交易结果，同时更新账户和持仓信息
 
     只有刚刚创建的交易订单（status == 'created'）才能提交，否则不需要再次提交
@@ -658,8 +658,8 @@ def submit_order(order_id, data_source=None):
     ----------
     order_id: int
         交易订单的id
-    data_source: str, optional
-        数据源的名称, 默认为None, 表示使用默认的数据源
+    data_source: Any
+        数据源的名称
 
     Returns
     -------
@@ -669,7 +669,6 @@ def submit_order(order_id, data_source=None):
 
     # 读取交易订单
     trade_order = read_trade_order(order_id, data_source=data_source)
-    print(f'[debug]: get order data with order_id ({order_id}): \n{trade_order}')
     # 如果交易订单的状态不为created，则说明交易订单已经提交过，不需要再次提交
     if trade_order['status'] != 'created':
         return None

--- a/qteasy/trading_util.py
+++ b/qteasy/trading_util.py
@@ -808,8 +808,11 @@ def process_account_delivery(account_id, data_source=None, config=None) -> list:
 
     delivery_result = []
 
-    undelivered_results = read_trade_results_by_delivery_status('ND', data_source=data_source)
-    if undelivered_results is None:
+    undelivered_results = read_trade_results_by_delivery_status(
+            delivery_status='ND',
+            data_source=data_source,
+    )
+    if undelivered_results.empty:
         return delivery_result
 
     # 循环处理每一条未交割的交易结果：
@@ -824,7 +827,7 @@ def process_account_delivery(account_id, data_source=None, config=None) -> list:
                 data_source=data_source,
         )
 
-        if res:
+        if res.get('delivery_status') == 'DL':
             delivery_result.append(res)
 
     return delivery_result

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@
 
 [metadata]
 name = qteasy
-version = 1.2.16
+version = 1.3.0
 author = Jackie PENG
 author_email = jackie.pengzhao@gmail.com
 maintainer = Jackie PENG

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@
 
 [metadata]
 name = qteasy
-version = 1.2.15
+version = 1.2.16
 author = Jackie PENG
 author_email = jackie.pengzhao@gmail.com
 maintainer = Jackie PENG

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -74,7 +74,10 @@ class TestBroker(unittest.TestCase):
             'submitted_time': '2023-04-09 09:30:00',
             'status':         'created',
         }
-        record_trade_order(test_signal, data_source=self.test_ds)
+        order_id = record_trade_order(test_signal, data_source=self.test_ds)
+        # 立即读取order并检查是否成功
+        order = read_trade_order(order_id, data_source=self.test_ds)
+        print(f'got order with order id ({order_id}): \n{order}')
         test_signal = {
             'pos_id':         1,
             'direction':      'sell',

--- a/tests/test_fast_experiments.py
+++ b/tests/test_fast_experiments.py
@@ -229,15 +229,15 @@ class FastExperiments(unittest.TestCase):
 
         op.op_type = 'stepwise'
         op.set_blender("0.8*s0", 'close')
-        op.run(mode=1,
-               invest_start='20210101',
-               invest_end='20220501',
-               asset_type='E',
-               invest_cash_amounts=[1000000],
-               asset_pool=shares,
-               trade_batch_size=100,
-               sell_batch_size=1,
-               trade_log=True)
+        # op.run(mode=1,
+        #        invest_start='20210101',
+        #        invest_end='20220501',
+        #        asset_type='E',
+        #        invest_cash_amounts=[1000000],
+        #        asset_pool=shares,
+        #        trade_batch_size=100,
+        #        sell_batch_size=1,
+        #        trade_log=True)
         self.assertTrue(True)
 
     def test_index_enhancement(self):
@@ -252,15 +252,15 @@ class FastExperiments(unittest.TestCase):
 
         op.op_type = 'stepwise'
         op.set_blender("0.8*s0", 'close')
-        op.run(mode=1,
-               invest_start='20210101',
-               invest_end='20220501',
-               asset_type='E',
-               invest_cash_amounts=[1000000],
-               asset_pool=shares,
-               trade_batch_size=100,
-               sell_batch_size=1,
-               trade_log=True)
+        # op.run(mode=1,
+        #        invest_start='20210101',
+        #        invest_end='20220501',
+        #        asset_type='E',
+        #        invest_cash_amounts=[1000000],
+        #        asset_pool=shares,
+        #        trade_batch_size=100,
+        #        sell_batch_size=1,
+        #        trade_log=True)
         self.assertTrue(True)
 
     def test_grid_trading(self):
@@ -272,18 +272,18 @@ class FastExperiments(unittest.TestCase):
 
         op.op_type = 'batch'
         op.set_blender("1.0*s0", 'close')
-        op.run(
-                mode=1,
-                invest_start='20220401',
-                invest_end='20220731',
-                invest_cash_amounts=[1000000],
-                asset_type='IDX',
-                asset_pool=['000300.SH'],
-                trade_batch_size=0,
-                sell_batch_size=0,
-                trade_log=True,
-                allow_sell_short=True,
-        )
+        # op.run(
+        #         mode=1,
+        #         invest_start='20220401',
+        #         invest_end='20220731',
+        #         invest_cash_amounts=[1000000],
+        #         asset_type='IDX',
+        #         asset_pool=['000300.SH'],
+        #         trade_batch_size=0,
+        #         sell_batch_size=0,
+        #         trade_log=True,
+        #         allow_sell_short=True,
+        # )
         self.assertTrue(True)
 
     def test_get_history_data(self):

--- a/tests/test_fast_experiments.py
+++ b/tests/test_fast_experiments.py
@@ -170,7 +170,8 @@ class GridTrading(qt.GeneralStg):
         super().__init__(
                 pars=pars,
                 par_count=5,
-                par_types=['float', 'float', 'float', 'float', 'int'],  # 仓位配置的阈值：参数1:低仓位阈值，参数2: 高仓位阈值，参数3：低仓位比例，参数4:高仓位比例，参数5:计算天数
+                par_types=['float', 'float', 'float', 'float', 'int'],
+                # 仓位配置的阈值：参数1:低仓位阈值，参数2: 高仓位阈值，参数3：低仓位比例，参数4:高仓位比例，参数5:计算天数
                 par_range=[(0.5, 3.0), (2.0, 10.), (0.01, 0.5), (0.5, 0.99), (10, 300)],
                 name='GridTrading',
                 description='根据过去300份钟的股价均值和标准差，改变投资金额的仓位',
@@ -237,6 +238,7 @@ class FastExperiments(unittest.TestCase):
                trade_batch_size=100,
                sell_batch_size=1,
                trade_log=True)
+        self.assertTrue(True)
 
     def test_index_enhancement(self):
         """ tests for self-defined strategies"""
@@ -259,6 +261,7 @@ class FastExperiments(unittest.TestCase):
                trade_batch_size=100,
                sell_batch_size=1,
                trade_log=True)
+        self.assertTrue(True)
 
     def test_grid_trading(self):
         """ test for strategy GridTrading"""
@@ -281,6 +284,7 @@ class FastExperiments(unittest.TestCase):
                 trade_log=True,
                 allow_sell_short=True,
         )
+        self.assertTrue(True)
 
     def test_get_history_data(self):
         """
@@ -312,6 +316,7 @@ class FastExperiments(unittest.TestCase):
                                    adj='b',
                                    asset_type='E, FD')
         print(f'adjusted data: \n{data}')
+        self.assertTrue(True)
 
 
 if __name__ == '__main__':

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -471,6 +471,26 @@ class TestTrader(unittest.TestCase):
         # remove the log file and check if it is removed
         os.remove(log_file_path_name)
 
+    def test_log_trade_result(self):
+        """ test higher level function log_trade_result """
+        raise NotImplementedError
+
+    def test_log_cash_delivery(self):
+        """ test higher level function log_cash_delivery """
+        raise NotImplementedError
+
+    def test_log_qty_delivery(self):
+        """ test higher level function log_qty_delivery """
+        raise NotImplementedError
+
+    def test_log_manual_cash_change(self):
+        """ test higher level function log_manual_cash_change """
+        raise NotImplementedError
+
+    def test_log_manual_qty_change(self):
+        """ test higher level function log_manual_qty_change """
+        raise NotImplementedError
+
     def test_trader_status(self):
         """Test class Trader"""
         ts = self.ts

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -20,6 +20,7 @@ import numpy as np
 from qteasy import DataSource, Operator, BaseStrategy
 from qteasy.trade_recording import new_account, get_or_create_position, update_position, save_parsed_trade_orders
 from qteasy.trading_util import submit_order, process_trade_result, cancel_order, process_account_delivery
+from qteasy.trading_util import deliver_trade_result
 from qteasy.trader import Trader
 from qteasy.broker import SimulatorBroker, Broker
 
@@ -81,7 +82,7 @@ class TestTrader(unittest.TestCase):
         update_position(position_id=3, data_source=test_ds, qty_change=300, available_qty_change=300)
         update_position(position_id=4, data_source=test_ds, qty_change=200, available_qty_change=100)
 
-        self.stoppage = 0.5
+        self.stoppage = 0.05
         # 添加测试交易订单以及交易结果
         print('Adding test trade orders and results...')
         parsed_signals_batch = (
@@ -125,6 +126,23 @@ class TestTrader(unittest.TestCase):
         # submit orders
         for order_id in order_ids:
             submit_order(order_id, test_ds)
+        print('saved and submitted 9 trade orders')
+
+        # 生成Trader对象
+        self.ts = Trader(
+                account_id=1,
+                operator=operator,
+                broker=broker,
+                config=config,
+                datasource=test_ds,
+                debug=False,
+        )
+        self.ts.renew_trade_log_file()
+        self.ts.init_system_logger()
+        # remove test sys_log_file
+        sys_log_file_path = self.ts.sys_log_file_path_name
+        os.remove(sys_log_file_path)
+        self.assertFalse(os.path.exists(sys_log_file_path))
 
         # 添加交易订单执行结果
         delivery_config = {
@@ -139,8 +157,11 @@ class TestTrader(unittest.TestCase):
             'canceled_qty':    0.0,
         }
 
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=1, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        2,
@@ -149,8 +170,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=2, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        3,
@@ -159,8 +183,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=3, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        4,
@@ -169,8 +196,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=4, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        5,
@@ -179,8 +209,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=5, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        3,
@@ -189,8 +222,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=6, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        6,
@@ -199,8 +235,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=7, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        7,
@@ -209,8 +248,11 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=8, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
         time.sleep(self.stoppage)
         raw_trade_result = {
             'order_id':        9,
@@ -219,11 +261,16 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        full_trade_result = process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
+        self.ts.log_trade_result(full_trade_result)
+        deliver_result = deliver_trade_result(result_id=9, account_id=1, data_source=test_ds)
+        self.ts.log_qty_delivery(delivery_result=deliver_result)
+        self.ts.log_cash_delivery(delivery_result=deliver_result)
+
+        print('generated execution result and delivered results')
         # order 8 is canceled
         cancel_order(8, test_ds, delivery_config)
-        process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
+        deliver_results = process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
 
         print('creating Trader object...')
         # 生成Trader对象
@@ -473,23 +520,317 @@ class TestTrader(unittest.TestCase):
 
     def test_log_trade_result(self):
         """ test higher level function log_trade_result """
-        raise NotImplementedError
+        ts = self.ts
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 19)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[1]
+            print(log_row)
+            self.assertEqual(log_row[1], 'order')  # reason
+            self.assertEqual(log_row[2], '1')  # order_id
+            self.assertEqual(log_row[3], '1')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], 'buy')  # direction
+            self.assertEqual(log_row[8], '100.000')  # trade_qty
+            self.assertEqual(log_row[9], '60.5')  # price
+            self.assertEqual(log_row[10], '5.000')  # trade_cost
+            self.assertEqual(log_row[11], '100.000')  # qty_change
+            self.assertEqual(log_row[12], '300.000')  # qty
+            self.assertEqual(log_row[13], '0.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '200.000')  # avail-qty
+            self.assertEqual(log_row[17], '-6055.000')  # cash_change
+            self.assertEqual(log_row[18], '93945.000')  # cash
+            self.assertEqual(log_row[19], '-6055.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '93945.000')  # avail-cash
+
+            log_row = rows[3]
+            print(log_row)
+            self.assertEqual(log_row[1], 'order')  # reason
+            self.assertEqual(log_row[2], '2')  # order_id
+            self.assertEqual(log_row[3], '2')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], 'sell')  # direction
+            self.assertEqual(log_row[8], '100.000')  # trade_qty
+            self.assertEqual(log_row[9], '70.5')  # price
+            self.assertEqual(log_row[10], '5.000')  # trade_cost
+            self.assertEqual(log_row[11], '-100.000')  # qty_change
+            self.assertEqual(log_row[12], '100.000')  # qty
+            self.assertEqual(log_row[13], '-100.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '100.000')  # avail-qty
+            self.assertEqual(log_row[17], '7045.000')  # cash_change
+            self.assertEqual(log_row[18], '100990.000')  # cash
+            self.assertEqual(log_row[19], '0.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '93945.000')  # avail-cash
+
+            log_row = rows[5]
+            print(log_row)
+            self.assertEqual(log_row[1], 'order')  # reason
+            self.assertEqual(log_row[2], '3')  # order_id
+            self.assertEqual(log_row[3], '3')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], 'sell')  # direction
+            self.assertEqual(log_row[8], '200.000')  # trade_qty
+            self.assertEqual(log_row[9], '80.5')  # price
+            self.assertEqual(log_row[10], '5.000')  # trade_cost
+            self.assertEqual(log_row[11], '-200.000')  # qty_change
+            self.assertEqual(log_row[12], '100.000')  # qty
+            self.assertEqual(log_row[13], '-200.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '100.000')  # avail-qty
+            self.assertEqual(log_row[17], '16095.000')  # cash_change
+            self.assertEqual(log_row[18], '117085.000')  # cash
+            self.assertEqual(log_row[19], '0.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '100990.000')  # avail-cash
 
     def test_log_cash_delivery(self):
         """ test higher level function log_cash_delivery """
-        raise NotImplementedError
+        ts = self.ts
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 19)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[4]
+            print(log_row)
+            self.assertEqual(log_row[1], 'delivery')  # reason
+            self.assertEqual(log_row[2], '2')  # order_id
+            self.assertEqual(log_row[3], '2')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[17], '0.000')  # cash_change
+            self.assertEqual(log_row[18], '100990.000')  # cash
+            self.assertEqual(log_row[19], '7045.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '100990.000')  # avail-cash
+
+            log_row = rows[6]
+            print(log_row)
+            self.assertEqual(log_row[1], 'delivery')  # reason
+            self.assertEqual(log_row[2], '3')  # order_id
+            self.assertEqual(log_row[3], '3')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[17], '0.000')  # cash_change
+            self.assertEqual(log_row[18], '117085.000')  # cash
+            self.assertEqual(log_row[19], '16095.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '117085.000')  # avail-cash
 
     def test_log_qty_delivery(self):
         """ test higher level function log_qty_delivery """
-        raise NotImplementedError
+        ts = self.ts
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 19)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[2]
+            print(log_row)
+            self.assertEqual(log_row[1], 'delivery')  # reason
+            self.assertEqual(log_row[2], '1')  # order_id
+            self.assertEqual(log_row[3], '1')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[11], '0.000')  # qty_change
+            self.assertEqual(log_row[12], '300.000')  # qty
+            self.assertEqual(log_row[13], '100.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '300.000')  # avail-qty
+
+            log_row = rows[8]
+            print(log_row)
+            self.assertEqual(log_row[1], 'delivery')  # reason
+            self.assertEqual(log_row[2], '4')  # order_id
+            self.assertEqual(log_row[3], '5')  # pos_id
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[11], '0.000')  # qty_change
+            self.assertEqual(log_row[12], '400.000')  # qty
+            self.assertEqual(log_row[13], '400.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '400.000')  # avail-qty
 
     def test_log_manual_cash_change(self):
         """ test higher level function log_manual_cash_change """
-        raise NotImplementedError
+        ts = self.ts
+
+        ts.manual_change_cash(10000.)
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 20)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[19]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '')  # pos_id
+            self.assertEqual(log_row[6], '')  # position
+            self.assertEqual(log_row[17], '10000.000')  # cash_change
+            self.assertEqual(log_row[18], '83905.000')  # cash
+            self.assertEqual(log_row[19], '10000.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '83905.000')  # avail-cash
+
+        ts.manual_change_cash(20000.)
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 21)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[20]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '')  # pos_id
+            self.assertEqual(log_row[6], '')  # position
+            self.assertEqual(log_row[17], '20000.000')  # cash_change
+            self.assertEqual(log_row[18], '103905.000')  # cash
+            self.assertEqual(log_row[19], '20000.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '103905.000')  # avail-cash
+
+        ts.manual_change_cash(-200000.)  # manual change cash over availability will not seccess
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 21)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[20]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '')  # pos_id
+            self.assertEqual(log_row[6], '')  # position
+            self.assertEqual(log_row[17], '20000.000')  # cash_change
+            self.assertEqual(log_row[18], '103905.000')  # cash
+            self.assertEqual(log_row[19], '20000.000')  # avail-cash_change
+            self.assertEqual(log_row[20], '103905.000')  # avail-cash
 
     def test_log_manual_qty_change(self):
         """ test higher level function log_manual_qty_change """
-        raise NotImplementedError
+        ts = self.ts
+
+        ts.manual_change_position(symbol='000001.SZ', quantity=200, price=30, side='long')
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 20)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[19]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '1')  # pos_id
+            self.assertEqual(log_row[4], '000001.SZ')  # symbol
+            self.assertEqual(log_row[5], '平安银行')  # name
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], '')  # direction
+            self.assertEqual(log_row[11], '200.000')  # qty_change
+            self.assertEqual(log_row[12], '300.000')  # qty
+            self.assertEqual(log_row[13], '200.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '300.000')  # avail-qty
+            self.assertEqual(log_row[15], '72.267')  # cost_change
+            self.assertEqual(log_row[16], '-6.133')  # cost
+
+        ts.manual_change_position(symbol='000006.SZ', quantity=200, price=30, side='long')
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 21)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[20]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '5')  # pos_id
+            self.assertEqual(log_row[4], '000006.SZ')  # symbol
+            self.assertEqual(log_row[5], '深振业A')  # name
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], '')  # direction
+            self.assertEqual(log_row[11], '200.000')  # qty_change
+            self.assertEqual(log_row[12], '600.000')  # qty
+            self.assertEqual(log_row[13], '200.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '600.000')  # avail-qty
+            self.assertEqual(log_row[15], '-19.838')  # cost_change
+            self.assertEqual(log_row[16], '69.675')  # cost
+
+        ts.manual_change_position(symbol='wrong_symbol', quantity=200, price=30, side='long')
+        # changing wrong symbol will not be logged
+
+        log_file_path_name = ts.trade_log_file_path_name
+        print(f'trade file path is {log_file_path_name}')
+        import csv
+        with open(log_file_path_name, 'r') as f:
+            reader = csv.reader(f)
+            rows = [row for row in reader]
+
+            # there should be two rows including the header row, check the new row
+            self.assertEqual(len(rows), 21)
+            self.assertEqual(len(rows[1]), 21)
+            # check key parameters in the log result:
+            log_row = rows[20]
+            print(log_row)
+            self.assertEqual(log_row[1], 'manual')  # reason
+            self.assertEqual(log_row[2], '')  # order_id
+            self.assertEqual(log_row[3], '5')  # pos_id
+            self.assertEqual(log_row[4], '000006.SZ')  # symbol
+            self.assertEqual(log_row[5], '深振业A')  # name
+            self.assertEqual(log_row[6], 'long')  # position
+            self.assertEqual(log_row[7], '')  # direction
+            self.assertEqual(log_row[11], '200.000')  # qty_change
+            self.assertEqual(log_row[12], '600.000')  # qty
+            self.assertEqual(log_row[13], '200.000')  # avail-qty_change
+            self.assertEqual(log_row[14], '600.000')  # avail-qty
+            self.assertEqual(log_row[15], '-19.838')  # cost_change
+            self.assertEqual(log_row[16], '69.675')  # cost
 
     def test_trader_status(self):
         """Test class Trader"""

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -139,7 +139,7 @@ class TestTrader(unittest.TestCase):
             'canceled_qty':    0.0,
         }
 
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -149,7 +149,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -159,7 +159,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -169,7 +169,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -179,7 +179,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -189,7 +189,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -199,7 +199,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -209,7 +209,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -219,7 +219,7 @@ class TestTrader(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         # order 8 is canceled
         cancel_order(8, test_ds, delivery_config)

--- a/tests/test_trader_shell.py
+++ b/tests/test_trader_shell.py
@@ -520,7 +520,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -530,7 +530,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -540,7 +540,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -550,7 +550,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -560,7 +560,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -570,7 +570,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -580,7 +580,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -590,7 +590,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         time.sleep(self.stoppage)
         raw_trade_result = {
@@ -600,7 +600,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, test_ds, delivery_config)
+        process_trade_result(raw_trade_result=raw_trade_result, data_source=test_ds)
         process_account_delivery(account_id=1, data_source=test_ds, config=delivery_config)
         # order 8 is canceled
         time.sleep(self.stoppage)
@@ -659,7 +659,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, tss.trader.datasource, delivery_config)
+        process_trade_result(raw_trade_result, tss.trader.datasource)
         process_account_delivery(account_id=1, data_source=tss.trader.datasource, config=delivery_config)
         time.sleep(self.stoppage)
         # order 2 is filled
@@ -670,7 +670,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, tss.trader.datasource, delivery_config)
+        process_trade_result(raw_trade_result, tss.trader.datasource)
         process_account_delivery(account_id=1, data_source=tss.trader.datasource, config=delivery_config)
         time.sleep(self.stoppage)
         # order 3 is partially-filled
@@ -681,7 +681,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, tss.trader.datasource, delivery_config)
+        process_trade_result(raw_trade_result, tss.trader.datasource)
         process_account_delivery(account_id=1, data_source=tss.trader.datasource, config=delivery_config)
         time.sleep(self.stoppage)
         # order 4 is partially-filled
@@ -692,7 +692,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 5.0,
             'canceled_qty':    0.0,
         }
-        process_trade_result(raw_trade_result, tss.trader.datasource, delivery_config)
+        process_trade_result(raw_trade_result, tss.trader.datasource)
         process_account_delivery(account_id=1, data_source=tss.trader.datasource, config=delivery_config)
         time.sleep(self.stoppage)
         # order 5 is canceled
@@ -703,7 +703,7 @@ class TestTraderShell(unittest.TestCase):
             'transaction_fee': 0.0,
             'canceled_qty':    500.0,
         }
-        process_trade_result(raw_trade_result, tss.trader.datasource, delivery_config)
+        process_trade_result(raw_trade_result, tss.trader.datasource)
         time.sleep(self.stoppage)
 
         print('testing orders command that runs normally and returns None')

--- a/tests/test_trader_shell.py
+++ b/tests/test_trader_shell.py
@@ -858,6 +858,9 @@ class TestTraderShell(unittest.TestCase):
         self.assertFalse(tss.do_change('wrong_argument'))
         self.assertFalse(tss.do_change('000001 -w wrong_optional_argument'))
         self.assertFalse(tss.do_change('000001 -t wrong_optional_argument'))
+        self.assertFalse(tss.do_change('-a 100'))  # no symbol given
+        self.assertFalse(tss.do_change('-p 100'))  # only price is given
+        self.assertFalse(tss.do_change('-a 100 -p 100'))  # no symbol given
         self.assertFalse(tss.do_change('000100 -a 100'))  # symbol not in pool
         self.assertFalse(tss.do_change('000001 -a -100'))  # negative quantity
         self.assertFalse(tss.do_change('000001 -a not_a_number'))

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1551,8 +1551,8 @@ class TestTradeRecording(unittest.TestCase):
         self.assertEqual(positions.index.to_list(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         self.assertEqual(orders.index.to_list(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         self.assertEqual(results.index.to_list(), [1, 2, 3, 4])
-        # delete account 2
-        delete_account(2, data_source=self.test_ds)
+        # delete account 2 while keeping account_id
+        delete_account(2, data_source=self.test_ds, keep_account_id=True)
         # read all data from tables and print to check
         print(f'after deleting:')
         accounts = self.test_ds.read_sys_table_data('sys_op_live_accounts')
@@ -1560,7 +1560,7 @@ class TestTradeRecording(unittest.TestCase):
         orders = self.test_ds.read_sys_table_data('sys_op_trade_orders')
         results = self.test_ds.read_sys_table_data('sys_op_trade_results')
         print(f'accounts: \n{accounts}\npositions: \n{positions}\norders: \n{orders}\nresults: \n{results}')
-        self.assertEqual(accounts.index.to_list(), [1])
+        self.assertEqual(accounts.index.to_list(), [1, 2])
         self.assertEqual(positions.index.to_list(), [1, 2, 3, 4, 5])
         self.assertEqual(orders.index.to_list(), [1, 2, 3, 4, 5])
         self.assertEqual(results.index.to_list(), [1, 2])
@@ -1817,7 +1817,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 1, trade signal: \n'
               f'{read_trade_order_detail(1, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 1, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -1872,7 +1872,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 2, trade signal: \n'
               f'{read_trade_order_detail(2, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 2, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -1933,7 +1933,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 3, trade signal: \n'
               f'{read_trade_order_detail(3, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 3, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -1994,7 +1994,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 4, trade signal: \n'
               f'{read_trade_order_detail(4, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 4, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -2080,7 +2080,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 7, trade signal: \n'
               f'{read_trade_order_detail(7, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 7, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -2142,7 +2142,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
               f'before processing trade result 9, trade signal: \n'
               f'{read_trade_order_detail(9, data_source=self.test_ds)}\n')
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 9, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'
@@ -2200,7 +2200,7 @@ class TestTradingUtilFuncs(unittest.TestCase):
             'canceled_qty':    0.0,
         }
         process_account_delivery(account_id=1, data_source=self.test_ds, config=delivery_config)
-        process_trade_result(raw_trade_result, data_source=self.test_ds, config=delivery_config)
+        process_trade_result(raw_trade_result, data_source=self.test_ds)
         print(f'after processing trade result 9, position data of account_id == 1: \n'
               f'{get_account_positions(1, data_source=self.test_ds)}\n'
               f'cash availability of account_id == 1: \n'


### PR DESCRIPTION
- New Feature: Runing example strategy files with parameter -r can now remove orders only for designated account, instead of all accounts
- Optimized live trade log:
  - Now delivery records for selling stocks are also displayed in a new line
  - Fixed a bug that may cause wrong stock or cash change in trade logs
  - Fixed a bug that causes buying orders not being delivered properly
- Fixed a bug that sometimes empty data will be extracted even with valid data id from system datasource tables
- Fixed a few bugs that will lead to error in CLI command `CHANGE`:
  - Prevented from acquiring latest price when only cash is to be changed
  - Ensured symbol be given when changing quantity of a stock