### PR TITLE
Quick bug fix to version 1.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - 作者: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.3.8`
+- Latest Version: `1.3.9`
 - License: BSD 3-Clause License
 
 `qteasy`是为量化交易人员开发的一套量化交易工具包，特点如下：

--- a/README_EN.md
+++ b/README_EN.md
@@ -48,7 +48,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.3.8`
+- Latest Version: `1.3.9`
 - License: BSD 3-Clause License
 
 `qteasy` is a quantitative trading utility package for quantitative traders, with the following features:

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -1,6 +1,11 @@
 # RELEASE HISTORY
 
-## 1.3.8 (2024-09-06)
+## 1.3.9 (2024-09-01)
+- Added setting key validation in `qt.update_start_up_setting()` to prevent from invalid values if the key is in qt_config_kwargs
+- improved print outs and return values of `qt.start_up_settings()`
+- improved the way the start up setting file is written to always keep intro messages
+
+## 1.3.8 (2024-09-01)
 - Added new features: now qteasy has multiple functions to access and modify start up setting file:
   - Added new function `qt.start_up_settings()`, to access and print contents of start up settings file
   - Added new function `qt.update_start_up_setting()`, to modify start up settings file

--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -4,5 +4,5 @@
 - Author: **Jackie PENG**
 - Email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.3.8`
+- Latest Version: `1.3.9`
 - License: BSD 3-Clause

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ project = 'qteasy'
 copyright = '2023, Jackie PENG'
 author = 'Jackie PENG'
 release = '1.3'
-version = '1.3.8'
+version = '1.3.9'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@
 - Author: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `1.3.8`
+- Latest Version: `1.3.9`
 - License: BSD 3-Clause
 
 Introduction

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: "qteasy"
-  version: "1.3.8"
+  version: "1.3.9"
 
 source:
-  git_rev: v1.3.7
+  git_rev: v1.3.9
   git_url: https://github.com/shepherdpp/qteasy
 
 requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qteasy"
-version = "1.3.8"
+version = "1.3.9"
 authors = [
   {name="jackie PENG", email="jackie.pengzhao@gmail.com" },
 ]

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -41,15 +41,15 @@ from .trade_recording import delete_account
 
 
 # qteasy版本信息
-__version__ = '1.3.8'
+__version__ = '1.3.9'
 version_info = Namespace(
         major=1,
         minor=3,
-        patch=8,
+        patch=9,
         short=(1, 3),
-        full=(1, 3, 8),
-        string='1.3.8',
-        tuple=('1', '3', '8'),
+        full=(1, 3, 9),
+        string='1.3.9',
+        tuple=('1', '3', '9'),
         releaselevel='beta',
 )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@
 
 [metadata]
 name = qteasy
-version = 1.3.8
+version = 1.3.9
 author = Jackie PENG
 author_email = jackie.pengzhao@gmail.com
 maintainer = Jackie PENG

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -47,13 +47,57 @@ class TestEntry(unittest.TestCase):
         qt.update_start_up_setting(test_key='test_value')
         config_lines = qt.start_up_settings()
         print(f'qteasy start up settings after update: {config_lines}')
-        self.assertTrue('test_key = test_value\n' in config_lines)
+        self.assertTrue('test_key = test_value' in config_lines)
+
+        # test special values in start up settings
+        qt.update_start_up_setting(test_key='test_value',
+                                   test_key2=123,
+                                   test_key3=0.123,
+                                   test_key4=True,
+                                   test_key5=False,
+                                   test_key6=None,
+                                   test_key7='None',
+                                   test_key8='False',
+                                   test_key9='3.14',
+                                   test_key10='3',
+        )
+        config_lines = qt.start_up_settings()
+        print(f'qteasy start up settings after update: {config_lines}')
+        self.assertTrue('test_key = test_value' in config_lines)
+        self.assertTrue('test_key2 = 123' in config_lines)
+        self.assertTrue('test_key3 = 0.123' in config_lines)
+        self.assertTrue('test_key4 = True' in config_lines)
+        self.assertTrue('test_key5 = False' in config_lines)
+        self.assertTrue('test_key6 = None' in config_lines)
+        self.assertTrue('test_key7 = "None"' in config_lines)
+        self.assertTrue('test_key8 = "False"' in config_lines)
+        self.assertTrue('test_key9 = "3.14"' in config_lines)
+        self.assertTrue('test_key10 = "3"' in config_lines)
 
         # test remove start up settings
         qt.remove_start_up_setting('test_key')
         config_lines = qt.start_up_settings()
         print(f'qteasy start up settings after remove: {config_lines}')
-        self.assertTrue('test_key = test_value\n' not in config_lines)
+        self.assertTrue('test_key = test_value' not in config_lines)
+
+        # remove other test keys
+        qt.remove_start_up_setting('test_key2', 'test_key3', 'test_key4', 'test_key5', 'test_key6',
+                                   'test_key7', 'test_key8', 'test_key9', 'test_key10')
+        config_lines = qt.start_up_settings()
+        print(f'qteasy start up settings after remove: {config_lines}')
+        self.assertTrue('test_key2 = 123' not in config_lines)
+        self.assertTrue('test_key3 = 0.123' not in config_lines)
+        self.assertTrue('test_key4 = True' not in config_lines)
+        self.assertTrue('test_key5 = False' not in config_lines)
+        self.assertTrue('test_key6 = None' not in config_lines)
+        self.assertTrue('test_key7 = "None"' not in config_lines)
+        self.assertTrue('test_key8 = "False"' not in config_lines)
+        self.assertTrue('test_key9 = "3.14"' not in config_lines)
+        self.assertTrue('test_key10 = "3"' not in config_lines)
+
+        # test updated invalid system settings
+        with self.assertRaises(ValueError):
+            qt.update_start_up_setting(test_key='test_value', mode='invalid_mode')
 
     def test_qt_built_ins(self):
         """ test functions built_ins, built_in_list, built_in_strategies, get_built_in_strategy, built_in_doc"""


### PR DESCRIPTION
- Added setting key validation in `qt.update_start_up_setting()` to prevent from invalid values if the key is in qt_config_kwargs
- improved print outs and return values of `qt.start_up_settings()`
- improved the way the start up setting file is written to always keep intro messages