### PR TITLE
Release 2.5.2: Live Trader CLI 可用性、dashboard 日志回放与 XtQuant 协作基础

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - 作者: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - Created: 2019, July, 16
-- Latest Version: `2.5.1` — [发布历史](https://qteasy.readthedocs.io/zh-cn/latest/RELEASE_HISTORY.html)
+- Latest Version: `2.5.2` — [发布历史](https://qteasy.readthedocs.io/zh-cn/latest/RELEASE_HISTORY.html)
 - Document: [简体中文](https://qteasy.readthedocs.io/zh-cn/latest/) · [English](https://qteasy.readthedocs.io/en/latest/) · [Deutsch](https://qteasy.readthedocs.io/de/latest/) · [Français](https://qteasy.readthedocs.io/fr/latest/) · [Español](https://qteasy.readthedocs.io/es/latest/) · [繁體中文](https://qteasy.readthedocs.io/zh-tw/latest/) · [日本語](https://qteasy.readthedocs.io/ja/latest/)
 - License: BSD 3-Clause License
 

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -2,6 +2,17 @@
 
 本页记录 qteasy 各版本的**用户可见**变更。升级前可查阅对应版本；2.0 大版本请参阅 [2.0 迁移指南](qteasy_2_migration_guide.md)。
 
+## 未发布（草案：xtQuant / MiniQMT 合作 S0）
+
+> **说明**：以下为 `qt_2.5_dev` 上 PR-0a / PR-0b 与契约文档的 **RELEASE 草案**，版本号与发布日由维护者在合并发布时确定（预计 PATCH，如 2.5.2）。正式条目发布前请勿对外引用为已发布版本。
+
+- **券商成交回报（Broker）**  
+  `transaction()` 现支持 **4 元组或 5 元组** 回报：第 5 项为可选 `broker_order_id`（真实柜台委托号）。内置 `SimulatorBroker` / `SimpleBroker` 仍使用 4 元组，行为与 2.5.1 兼容。修复分段成交时本笔成交量误当作订单总量校验的问题，避免多笔成交回报校验失败。5 元组中的委托号可写入 `raw_trade_result['broker_order_id']`，供实盘对账与撤单映射。
+- **实盘配置**  
+  `live_trade_broker_type` 与 `qt.configure(...)` 现允许取值 **`xtquant`**。仅表示配置合法；实际使用须安装并注册扩展包（如 `qteasy-xtquant` 的 `register()`），未注册时 `get_broker('xtquant')` 可能仍回落为模拟券商。
+- **文档**  
+  新增英文契约 [XtQuant / MiniQMT Broker Adapter Contract v1](live_trading/4a-xtquant-broker-adapter-contract-v1.md)，说明 `submit_with_ack`、`poll_fills` 与 5 元组语义及禁止对 QMT 双重下单；**不**包含 fork 中 Trader 大段改动或 MySQL-only 数据策略。
+
 ## 2.5.1 (2026-05-18)
 
 - **Trader Shell dashboard**  

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -5,7 +5,7 @@
 ## 2.5.2 (2026-05-24)
 
 - **Trader Shell CLI 可用性**  
-  **`orders`** 列表现显示本地订单 ID（`id`）与券商委托号（`broker_id`，若有），便于对照 **`cancel ORDER_ID`** 撤单或排障。**`history`** 仅展示确有成交的记录，未成交或已取消且无成交量的订单不再混入列表。**`task -l`** 默认列出排队中的任务（`queued`），**`task -l -s all`** 与 **`tasks`** 以与 **`schedule`** 一致的表格展示任务 ID、名称、状态与参数；仍可用 **`task TASK_ID`** 查看详情、**`task TASK_ID -c`** 取消排队任务。**`broker`**、**`gate`**、**`reconcile`**、**`liveconfig`** 改为分段键值可读输出（风格接近 **`overview`** / **`config`**），布尔项以颜色区分；程序化集成请直接调用 Trader API。**`rotatelogs`** 执行前预览待删文件并提示确认，非交互环境须加 **`--yes` / `-y`**；别名 **`rotatelog`**、**`rotate-logs`** 仍可用。
+  **`orders`** 列表现显示本地订单 ID（`id`）与券商委托号（`broker_id`，若有），便于对照 **`cancel ORDER_ID`** 撤单或排障。**`history`** 仅展示确有成交的记录，未成交或已取消且无成交量的订单不再混入列表。**`task -l`** 默认列出排队中的任务（`queued`），**`task -l -s all`** 与 **`tasks`** 以与 **`schedule`** 一致的表格展示任务 ID、名称、状态与参数；仍可用 **`task TASK_ID`** 查看详情、**`task TASK_ID -c`** 取消排队任务。**`broker`**、**`gate`**、**`reconcile`**、**`liveconfig`** 改为分段键值可读输出（风格接近 **`overview`** / **`config`**），布尔项以颜色区分；程序化集成请直接调用 Trader API。**`rotatelogs`** 执行前预览待删文件并提示确认，非交互环境须加 **`--yes` / `-y`**；别名 **`rotatelog`**、**`rotate-logs`** 仍可用。从命令模式回到 **dashboard** 时，**`-r`** 回放的系统日志条数与设定一致（按逻辑日志条目计数）；非 DEBUG 模式下不再因先截物理行再过滤 DEBUG 而明显变少。
 - **券商成交回报（Broker）**  
   券商 **`transaction()`** 回报现支持 **4 元组或 5 元组**：第 5 项为可选真实柜台委托号。内置模拟券商仍使用 4 元组，与 2.5.1 兼容。修复分段成交时误将本笔成交量当作订单总量校验的问题；5 元组委托号可写入成交结果，供实盘对账与撤单映射。
 - **实盘配置（XtQuant 协作）**  

--- a/docs/source/RELEASE_HISTORY.md
+++ b/docs/source/RELEASE_HISTORY.md
@@ -2,16 +2,16 @@
 
 本页记录 qteasy 各版本的**用户可见**变更。升级前可查阅对应版本；2.0 大版本请参阅 [2.0 迁移指南](qteasy_2_migration_guide.md)。
 
-## 未发布（草案：xtQuant / MiniQMT 合作 S0）
+## 2.5.2 (2026-05-24)
 
-> **说明**：以下为 `qt_2.5_dev` 上 PR-0a / PR-0b 与契约文档的 **RELEASE 草案**，版本号与发布日由维护者在合并发布时确定（预计 PATCH，如 2.5.2）。正式条目发布前请勿对外引用为已发布版本。
-
+- **Trader Shell CLI 可用性**  
+  **`orders`** 列表现显示本地订单 ID（`id`）与券商委托号（`broker_id`，若有），便于对照 **`cancel ORDER_ID`** 撤单或排障。**`history`** 仅展示确有成交的记录，未成交或已取消且无成交量的订单不再混入列表。**`task -l`** 默认列出排队中的任务（`queued`），**`task -l -s all`** 与 **`tasks`** 以与 **`schedule`** 一致的表格展示任务 ID、名称、状态与参数；仍可用 **`task TASK_ID`** 查看详情、**`task TASK_ID -c`** 取消排队任务。**`broker`**、**`gate`**、**`reconcile`**、**`liveconfig`** 改为分段键值可读输出（风格接近 **`overview`** / **`config`**），布尔项以颜色区分；程序化集成请直接调用 Trader API。**`rotatelogs`** 执行前预览待删文件并提示确认，非交互环境须加 **`--yes` / `-y`**；别名 **`rotatelog`**、**`rotate-logs`** 仍可用。
 - **券商成交回报（Broker）**  
-  `transaction()` 现支持 **4 元组或 5 元组** 回报：第 5 项为可选 `broker_order_id`（真实柜台委托号）。内置 `SimulatorBroker` / `SimpleBroker` 仍使用 4 元组，行为与 2.5.1 兼容。修复分段成交时本笔成交量误当作订单总量校验的问题，避免多笔成交回报校验失败。5 元组中的委托号可写入 `raw_trade_result['broker_order_id']`，供实盘对账与撤单映射。
-- **实盘配置**  
-  `live_trade_broker_type` 与 `qt.configure(...)` 现允许取值 **`xtquant`**。仅表示配置合法；实际使用须安装并注册扩展包（如 `qteasy-xtquant` 的 `register()`），未注册时 `get_broker('xtquant')` 可能仍回落为模拟券商。
+  券商 **`transaction()`** 回报现支持 **4 元组或 5 元组**：第 5 项为可选真实柜台委托号。内置模拟券商仍使用 4 元组，与 2.5.1 兼容。修复分段成交时误将本笔成交量当作订单总量校验的问题；5 元组委托号可写入成交结果，供实盘对账与撤单映射。
+- **实盘配置（XtQuant 协作）**  
+  **`live_trade_broker_type`** 与 **`qt.configure(...)`** 现允许取值 **`xtquant`**（须安装并注册扩展包后方可实际接入；未注册时可能回落为模拟券商）。
 - **文档**  
-  新增英文契约 [XtQuant / MiniQMT Broker Adapter Contract v1](live_trading/4a-xtquant-broker-adapter-contract-v1.md)，说明 `submit_with_ack`、`poll_fills` 与 5 元组语义及禁止对 QMT 双重下单；**不**包含 fork 中 Trader 大段改动或 MySQL-only 数据策略。
+  新增英文契约 [XtQuant / MiniQMT Broker Adapter Contract v1](live_trading/4a-xtquant-broker-adapter-contract-v1.md)，说明受理、轮询成交与 5 元组语义及禁止对 QMT 双重下单。
 
 ## 2.5.1 (2026-05-18)
 

--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -4,6 +4,6 @@
 - 作者: **Jackie PENG**
 - Email: *jackie_pengzhao@163.com*
 - 创建日期: 2019, July, 16
-- 最新版本: `2.5.1`
+- 最新版本: `2.5.2`
 - [发布历史](RELEASE_HISTORY.md)
 - License: BSD 3-Clause

--- a/docs/source/api/api_reference.rst
+++ b/docs/source/api/api_reference.rst
@@ -48,6 +48,7 @@ qteasy的所有配置变量
    - 先跑起来：``live_trading/2-configuration-and-run.md``
    - 理解拒单与状态：``live_trading/3-risk-and-order-lifecycle.md``
    - 扩展 Broker：``live_trading/4-broker-adapter-and-integration.md``
+   - XtQuant/MiniQMT 契约 v1（英文）：``live_trading/4a-xtquant-broker-adapter-contract-v1.md``
    - 排错复盘：``live_trading/5-artifacts-and-troubleshooting.md``
    - 双路径实操教程：``tutorials/8-live-trade-risk-and-broker-walkthrough.md``
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ project = 'qteasy'
 copyright = '2023, Jackie PENG'
 author = 'Jackie PENG'
 version = '2.5'
-release = '2.5.1'
+release = '2.5.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -17,7 +17,7 @@ pip install qteasy
 输出如下：
 
 ```
-2.5.1
+2.5.2
 ```
 
 - [qteasy发布历史](RELEASE_HISTORY.md) — 各版本变更说明，升级前可查阅

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@
 - 作者: **Jackie PENG**
 - email: *jackie_pengzhao@163.com*
 - 创建日期: 2019, July, 16
-- 最新版本: `2.5.1` — :doc:`发布历史 <RELEASE_HISTORY>`
+- 最新版本: `2.5.2` — :doc:`发布历史 <RELEASE_HISTORY>`
 - License: BSD 3-Clause
 
 简介

--- a/docs/source/live_trading/4-broker-adapter-and-integration.md
+++ b/docs/source/live_trading/4-broker-adapter-and-integration.md
@@ -58,7 +58,7 @@ Operator.run_live_trade()
 | 接口 | 语义 | simulator 上您会看到 | 真实 QMT（规划中） |
 |------|------|----------------------|---------------------|
 | `connect` / `disconnect` | 会话 | 内部标志置位；非真实登录 | 真实登录与重连 |
-| `submit_with_ack` | 同步受理 | 返回 accepted、模拟 broker_order_id 等 | 柜台真实受理结果 |
+| `submit_with_ack` | 同步受理 | 返回 accepted、模拟 broker_order_id 等 | 柜台真实受理结果（见 :doc:`4a-xtquant-broker-adapter-contract-v1`） |
 | `poll_fills` | 异步回报 | 模拟成交队列 | 真实成交推送/轮询 |
 | `get_remote_*` | 远端账本 | 常为空或 None | 对账、门禁、sync 的数据源 |
 | `cancel` | 撤单 | 模拟实现 | 真实撤单号映射 |
@@ -91,6 +91,8 @@ Operator.run_live_trade()
 
 ## 4. 扩展新 Broker 类型
 
+**XtQuant / MiniQMT**：配置项 ``live_trade_broker_type='xtquant'`` 已在 2.5.1 白名单中；实现细节与禁止双重下单等规则见英文契约 :doc:`4a-xtquant-broker-adapter-contract-v1`（协作方 PR 评审基准）。
+
 注册工厂（示例）：
 
 ```python
@@ -98,6 +100,15 @@ from qteasy.broker import register_broker_factory
 
 register_broker_factory('my_broker', MyBrokerFactory)
 # qt.configure(live_trade_broker_type='my_broker')
+```
+
+独立扩展包（推荐用于 QMT）：
+
+```python
+import qteasy_xtquant
+
+qteasy_xtquant.register()
+# qt.configure(live_trade_broker_type='xtquant')
 ```
 
 **CLI `sync`（别名 `pull-state`）**：当前为**预留**，执行会打印 `[NOT_IMPLEMENTED] ...`，表示真实「从券商拉状态」尚未实现；对接 QMT 后将替换为可用实现。

--- a/docs/source/live_trading/4-broker-adapter-and-integration.md
+++ b/docs/source/live_trading/4-broker-adapter-and-integration.md
@@ -91,7 +91,7 @@ Operator.run_live_trade()
 
 ## 4. 扩展新 Broker 类型
 
-**XtQuant / MiniQMT**：配置项 ``live_trade_broker_type='xtquant'`` 已在 2.5.1 白名单中；实现细节与禁止双重下单等规则见英文契约 :doc:`4a-xtquant-broker-adapter-contract-v1`（协作方 PR 评审基准）。
+**XtQuant / MiniQMT**：配置项 ``live_trade_broker_type='xtquant'`` 已在 2.5.2 白名单中；实现细节与禁止双重下单等规则见英文契约 :doc:`4a-xtquant-broker-adapter-contract-v1`（协作方 PR 评审基准）。
 
 注册工厂（示例）：
 

--- a/docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md
+++ b/docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md
@@ -1,6 +1,6 @@
 # XtQuant / MiniQMT Broker Adapter Contract (v1)
 
-> **Audience**: Contributors implementing `qteasy-xtquant` or reviewing MiniQMT integration against qteasy **2.5.1+**.  
+> **Audience**: Contributors implementing `qteasy-xtquant` or reviewing MiniQMT integration against qteasy **2.5.2+**.  
 > **Language**: English (normative for collaboration).  
 > **Related**: :doc:`4-broker-adapter-and-integration`, `qteasy.trade_io`, `qteasy.broker`.
 
@@ -29,7 +29,7 @@ This document is the **v1 contract** for wiring **XtQuant / MiniQMT** into qteas
 
 ### 1.1 Configuration
 
-`build_live_trade_config(..., live_trade_broker_type='xtquant')` and `qt.configure(live_trade_broker_type='xtquant')` are **allowed** as of qteasy 2.5.1 (PR-0b).
+`build_live_trade_config(..., live_trade_broker_type='xtquant')` and `qt.configure(live_trade_broker_type='xtquant')` are **allowed** as of qteasy 2.5.2 (PR-0b).
 
 This only validates the **string**; it does **not** install XtQuant or register the broker class.
 
@@ -136,7 +136,7 @@ Trader.submit_trade_order()
 
 ## 4. Fill delivery: `poll_fills`, `result_queue`, and `broker.run`
 
-qteasy 2.5.1 uses **two** fill paths. XtQuant adapters must support the **Trader main loop** path.
+qteasy 2.5.2 uses **two** fill paths. XtQuant adapters must support the **Trader main loop** path.
 
 ### 4.1 Primary path (Trader live loop)
 
@@ -243,7 +243,7 @@ If `submit()` is used in tests with 5-tuples, `broker_order_id` in each fill sho
 
 ## 7. Differences from helloeveroneday fork (ext-dev)
 
-| Topic | Fork tendency | qteasy 2.5.1 + this contract |
+| Topic | Fork tendency | qteasy 2.5.2 + this contract |
 |-------|---------------|------------------------------|
 | Trader changes | Large pre-check / DIAG / queue drain | **No** merge; use `RiskManager` + Broker adapter |
 | Tuple contract | 5-tuple only | 4-tuple allowed for simulators; **XtQuant uses 5-tuple** |
@@ -272,4 +272,4 @@ Problem definitions from fork production incidents (ghost orders, rebalance race
 - Code: `qteasy/broker.py`, `qteasy/trader.py`, `qteasy/trade_io.py`  
 - Upstream tests: `tests/test_broker_order_id_persistence_20260429.py`, `tests/test_trade_io_contracts.py`
 
-**Contract version**: v1 (2026-05; qteasy 2.5.1, PR-0a/0b). Changes should be discussed via GitHub issue before implementation drift.
+**Contract version**: v1 (2026-05; qteasy 2.5.2, PR-0a/0b). Changes should be discussed via GitHub issue before implementation drift.

--- a/docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md
+++ b/docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md
@@ -1,0 +1,275 @@
+# XtQuant / MiniQMT Broker Adapter Contract (v1)
+
+> **Audience**: Contributors implementing `qteasy-xtquant` or reviewing MiniQMT integration against qteasy **2.5.1+**.  
+> **Language**: English (normative for collaboration).  
+> **Related**: :doc:`4-broker-adapter-and-integration`, `qteasy.trade_io`, `qteasy.broker`.
+
+This document is the **v1 contract** for wiring **XtQuant / MiniQMT** into qteasy’s live-trading stack. It does **not** replace the general Broker adapter guide; it adds QMT-specific rules on top of it.
+
+---
+
+## 0. Scope and non-goals
+
+**In scope (v1)**
+
+- `live_trade_broker_type='xtquant'` (configuration whitelist; factory registration via extension package)
+- Real **broker order IDs** from QMT at accept time and in fill reports
+- `submit_with_ack` + `poll_fills` as the **primary** Trader path
+- `transaction()` as an internal generator yielding **4- or 5-tuples** (QMT adapters must yield **5-tuples** with real IDs)
+
+**Out of scope (v1)**
+
+- Merging fork `trader.py` blocks (pre-check locks, DIAG spam, manual `result_queue` drain, MySQL-only data policy)
+- Hard `import brokers` or `from qteasy_xtquant` inside `qteasy/broker.py`
+- Price channel `live_price_acquire_channel='xtquant'` (see separate PR for `xtfuncs` / `data_channels`)
+
+---
+
+## 1. Configuration and registration
+
+### 1.1 Configuration
+
+`build_live_trade_config(..., live_trade_broker_type='xtquant')` and `qt.configure(live_trade_broker_type='xtquant')` are **allowed** as of qteasy 2.5.1 (PR-0b).
+
+This only validates the **string**; it does **not** install XtQuant or register the broker class.
+
+### 1.2 Extension package registration (required for real QMT)
+
+```python
+import qteasy_xtquant
+
+qteasy_xtquant.register()  # calls register_broker_factory('xtquant', XtQuantBroker)
+```
+
+**Do not** patch `qteasy.broker.get_broker()` to `from brokers import ...`.
+
+Until `register()` runs, `get_broker('xtquant')` may fall back to `SimulatorBroker` (misleading for production). Live runs must call `register()` before `Operator.run(..., mode=0)`.
+
+---
+
+## 2. Data contracts (`qteasy.trade_io`)
+
+All orders and raw fills must pass:
+
+- `validate_trade_order()` — shape of orders entering the Broker layer  
+- `validate_raw_trade_result()` — shape of fills leaving the Broker layer  
+
+TypedDict references (informative; **validators are authoritative**):
+
+| Name | Module | Purpose |
+|------|--------|---------|
+| `TradeOrderDict` | `qteasy.trade_io` | Order dict before / during Broker handling |
+| `RawTradeResultDict` | `qteasy.trade_io` | One fill/cancel slice before `process_trade_result` |
+
+### 2.1 `TradeOrderDict` (required keys)
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `order_id` | int | Local DB order id |
+| `pos_id` | int | Position id |
+| `direction` | str | `'buy'` / `'sell'` |
+| `order_type` | str | `'market'` / `'limit'` |
+| `qty` | float | > 0 |
+| `price` | float | > 0 |
+| `status` | str | Must be `'submitted'` when passed to Broker |
+| `submitted_time` | str or None | ISO-like timestamp string |
+
+Optional: `symbol`, `position` (validated if present).
+
+### 2.2 `RawTradeResultDict` (required keys)
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `order_id` | int | Matches local order |
+| `filled_qty` | float | ≥ 0 |
+| `price` | float | ≥ 0; 0 when canceled-only slice |
+| `transaction_fee` | float | ≥ 0 |
+| `execution_time` | str | Parseable datetime string |
+| `canceled_qty` | float | ≥ 0 |
+| `delivery_amount` | float | Often 0 at Broker layer |
+| `delivery_status` | str | e.g. `'ND'` |
+
+Optional (recommended for QMT):
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `broker_order_id` | str | **Real QMT order id** when known |
+| `status` | str | `'filled'` / `'partial-filled'` / `'canceled'` |
+| `raw_status` | str | Broker-native status text/code |
+
+---
+
+## 3. `submit_with_ack` — accept phase
+
+`XtQuantBroker` **must override** the base implementation that only enqueues and returns a **synthetic** id (`SimulatorBroker:order_id:seq`).
+
+### 3.1 Call flow
+
+```text
+Trader.submit_trade_order()
+  → record_trade_order (local row, status created)
+  → broker.connect()
+  → broker.submit_with_ack(order)
+  → if accepted: update_trade_order(status='submitted', broker_order_id=..., broker_name=...)
+  → if rejected: update_trade_order(status='rejected'), broker_order_id empty
+```
+
+### 3.2 Return dict (normative)
+
+| Field | Type | When `accepted=True` | When `accepted=False` |
+|-------|------|----------------------|------------------------|
+| `accepted` | bool | `True` | `False` |
+| `order_id` | int or None | Local `order_id` if parseable | Same |
+| `broker_order_id` | str | **Real QMT order id** (non-empty) | `''` |
+| `reason` | str | `''` | English explanation |
+| `reason_code` | str | `''` | e.g. exception class name or broker code |
+
+**DB rule**: On success, Trader persists `broker_order_id` to `sys_op_trade_orders` **before** async fills are processed. Reconciliation and cancel must use this id.
+
+### 3.3 QMT-specific accept rules
+
+- Perform **one** QMT submit per local `order_id` intent in `submit_with_ack`.
+- Do **not** submit again in `transaction()` for the same intent (see §5).
+- On QMT reject, return `accepted=False` with clear `reason` / `reason_code`; do not leave the local row `submitted`.
+
+---
+
+## 4. Fill delivery: `poll_fills`, `result_queue`, and `broker.run`
+
+qteasy 2.5.1 uses **two** fill paths. XtQuant adapters must support the **Trader main loop** path.
+
+### 4.1 Primary path (Trader live loop)
+
+```text
+Trader main loop (trading day)
+  → broker.poll_fills(timeout=0)
+  → for each raw dict: validate_raw_trade_result
+  → add_task('process_result', raw)
+  → process_trade_result → ledger / order status updates
+```
+
+Implement `poll_fills` to return fills produced by QMT callbacks (deque / internal buffer), each dict satisfying `RawTradeResultDict`.
+
+### 4.2 Legacy path (`broker.run` thread)
+
+```text
+broker.run() loop
+  → order_queue.get()
+  → _get_result(order)
+       → for slice in transaction(...): build raw_trade_result → result_queue.put()
+```
+
+`poll_fills` **also** drains `result_queue` when connected (compat). For QMT:
+
+- Callback thread should push normalized fills into the structure `poll_fills` reads (preferred), **or**
+- Bridge callback → `result_queue` without blocking Trader.
+
+### 4.3 Relationship diagram
+
+```mermaid
+flowchart TB
+  subgraph accept [Accept phase - sync]
+    T1[Trader.submit_trade_order]
+    ACK[broker.submit_with_ack]
+    QMT1[QMT order API once]
+    DB[(sys_op_trade_orders broker_order_id)]
+    T1 --> ACK --> QMT1 --> DB
+  end
+
+  subgraph fills [Fill phase - async]
+    CB[QMT callback thread]
+    BUF[Adapter buffer or result_queue]
+    POLL[Trader poll_fills]
+    PR[process_trade_result]
+    CB --> BUF --> POLL --> PR
+  end
+
+  ACK -.->|must not submit again| CB
+```
+
+**Invariant**: Accept phase owns **placement**; fill phase owns **execution reports**. Same local `order_id` + same QMT `broker_order_id` tie the two phases together.
+
+---
+
+## 5. `transaction()` — 4/5-tuple generator
+
+Base class `Broker.transaction()` may yield:
+
+- **4-tuple**: `(result_type, qty, price, fee)` — built-in simulators  
+- **5-tuple**: `(result_type, qty, price, fee, broker_order_id)` — **required for XtQuant**
+
+| Component | Meaning |
+|-----------|---------|
+| `result_type` | `'filled'`, `'partial-filled'`, or `'canceled'` |
+| `qty` | **This slice** quantity; must be `0 < qty <= order_qty` (order total) |
+| `price` | Fill price; `0` if `result_type=='canceled'` |
+| `fee` | Fee for this slice; ≥ 0 |
+| `broker_order_id` | str or None; if str, copied to `raw_trade_result['broker_order_id']` |
+
+`_get_result` validates each yield against the **order total** `order_qty` (not the previous slice qty). Partial fills must not reuse the loop variable name `qty` for order size (fixed in qteasy PR-0a).
+
+### 5.1 Forbidden: double submit to QMT
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Accepted: submit_with_ack places order on QMT
+  Accepted --> Filling: callbacks yield 5-tuples only
+  Filling --> Filling: partial-filled slices
+  Filling --> Done: filled or canceled
+  Done --> [*]
+
+  note right of Accepted
+    Do NOT call QMT insert/order API
+    again in transaction() for same intent
+  end note
+```
+
+| Pattern | Verdict |
+|---------|---------|
+| `submit_with_ack` → QMT order API; `transaction()` only maps callbacks → 5-tuple | **Correct** |
+| `submit_with_ack` only enqueues; `transaction()` calls QMT order API | **Wrong** (double submit risk) |
+| Both `submit_with_ack` and `transaction()` call QMT order API | **Forbidden** |
+
+---
+
+## 6. `submit()` vs `submit_with_ack` (extension testing)
+
+`Broker.submit()` runs `transaction()` **synchronously** and appends to `_pending_fills`. Useful for unit tests; **Trader production path uses `submit_with_ack` + `poll_fills`.**
+
+If `submit()` is used in tests with 5-tuples, `broker_order_id` in each fill should still be the **real** QMT id when simulating production.
+
+---
+
+## 7. Differences from helloeveroneday fork (ext-dev)
+
+| Topic | Fork tendency | qteasy 2.5.1 + this contract |
+|-------|---------------|------------------------------|
+| Trader changes | Large pre-check / DIAG / queue drain | **No** merge; use `RiskManager` + Broker adapter |
+| Tuple contract | 5-tuple only | 4-tuple allowed for simulators; **XtQuant uses 5-tuple** |
+| Broker registration | `from brokers import ...` in `get_broker` | `register_broker_factory('xtquant', ...)` only |
+| Accept API | Often queue-only | **`submit_with_ack` with real boid** |
+| Data layer | MySQL-only assumptions | Not required for upstream PR |
+
+Problem definitions from fork production incidents (ghost orders, rebalance race) remain valuable; implementations belong in **Broker / extension package / docs**, not fork-style `trader.py` patches.
+
+---
+
+## 8. Minimal acceptance (Spike / S0)
+
+- [ ] `submit_with_ack` returns `accepted=True` and **non-synthetic** `broker_order_id` on Windows + miniQMT  
+- [ ] DB row `sys_op_trade_orders.broker_order_id` matches QMT UI order id  
+- [ ] `poll_fills` → `process_result` processes at least one fill  
+- [ ] No duplicate QMT order for one local `order_id`  
+- [ ] Mac/Linux CI: mock `xtquant` module tests without real QMT  
+
+---
+
+## 9. References
+
+- General adapter guide: :doc:`4-broker-adapter-and-integration`  
+- Order lifecycle: :doc:`3-risk-and-order-lifecycle`  
+- Code: `qteasy/broker.py`, `qteasy/trader.py`, `qteasy/trade_io.py`  
+- Upstream tests: `tests/test_broker_order_id_persistence_20260429.py`, `tests/test_trade_io_contracts.py`
+
+**Contract version**: v1 (2026-05; qteasy 2.5.1, PR-0a/0b). Changes should be discussed via GitHub issue before implementation drift.

--- a/docs/source/live_trading/index.rst
+++ b/docs/source/live_trading/index.rst
@@ -21,7 +21,7 @@
 
 - **初学者**：按下方「建议阅读顺序」读 1 → 2 → 3 → 5 即可跑通并会排错。
 - **已跑通 live**：可查阅第 6、8 章做快照/门禁与 CLI 运维。
-- **准备对接真实柜台（如 QMT）**：在第 4 章阅读 Broker 适配说明。
+- **准备对接真实柜台（如 QMT）**：阅读 :doc:`4a-xtquant-broker-adapter-contract-v1`（英文契约 v1），再读 :doc:`4-broker-adapter-and-integration`。
 
 建议阅读顺序
 ------------
@@ -33,9 +33,10 @@
 3. :doc:`3-risk-and-order-lifecycle` — 风控与订单状态
 4. :doc:`5-artifacts-and-troubleshooting` — 产物与排错（建议先于 Broker 集成阅读）
 5. :doc:`4-broker-adapter-and-integration` — 券商适配（进阶）
-6. :doc:`6-trader-snapshot-gate` — 策略快照与启动门禁
-7. :doc:`7-manual-smoke-live-grid-roadmap` — 手工冒烟清单
-8. :doc:`8-cli-trader-capability-matrix` — CLI 能力对照表
+6. :doc:`4a-xtquant-broker-adapter-contract-v1` — XtQuant/MiniQMT 契约 v1（英文，协作必读）
+7. :doc:`6-trader-snapshot-gate` — 策略快照与启动门禁
+8. :doc:`7-manual-smoke-live-grid-roadmap` — 手工冒烟清单
+9. :doc:`8-cli-trader-capability-matrix` — CLI 能力对照表
 
 .. toctree::
    :maxdepth: 1
@@ -45,6 +46,7 @@
    3-risk-and-order-lifecycle
    5-artifacts-and-troubleshooting
    4-broker-adapter-and-integration
+   4a-xtquant-broker-adapter-contract-v1
    6-trader-snapshot-gate
    7-manual-smoke-live-grid-roadmap
    8-cli-trader-capability-matrix

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: "qteasy"
-version: "2.5.1"
+version: "2.5.2"
 
 source:
-  git_rev: v2.5.1
+  git_rev: v2.5.2
   git_url: https://github.com/shepherdpp/qteasy
 
 requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qteasy"
-version = "2.5.1"
+version = "2.5.2"
 authors = [
   {name="jackie PENG", email="jackie.pengzhao@gmail.com" },
 ]

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -242,6 +242,73 @@ def _refresh_log_paths() -> None:
     os.makedirs(QT_TRADE_LOG_PATH, exist_ok=True)
 
 
+def _parse_trade_log_file_created_time(full_path: str, name: str) -> Optional[datetime]:
+    """解析 trade/risk 日志文件的创建时间（文件名时间戳优先，失败则用 mtime）。"""
+    is_trade_csv = (
+        name.endswith('.csv')
+        and (name.startswith('trade_log_') or name.startswith('trade_summary_') or name.startswith('value_curve_'))
+    )
+    is_risk_log = name.endswith('.risk.log')
+    if not (is_trade_csv or is_risk_log):
+        return None
+
+    created_time: Optional[datetime] = None
+    try:
+        if is_trade_csv:
+            stem = name[:-4]
+            parts = stem.split('_')
+            if len(parts) >= 3:
+                date_str, time_str = parts[-2], parts[-1]
+                created_time = datetime.strptime(f'{date_str}_{time_str}', '%Y%m%d_%H%M%S')
+    except Exception:
+        created_time = None
+
+    if created_time is None:
+        try:
+            created_time = datetime.fromtimestamp(os.path.getmtime(full_path))
+        except Exception:
+            return None
+    return created_time
+
+
+def _collect_expired_trade_log_files(base_path: str, keep_days: int) -> list[tuple[str, datetime]]:
+    """列出保留天数阈值之外、将被轮换删除的 trade/risk 日志文件。
+
+    Parameters
+    ----------
+    base_path : str
+        日志目录路径。
+    keep_days : int
+        保留天数。
+
+    Returns
+    -------
+    list[tuple[str, datetime]]
+        ``(full_path, created_time)`` 列表，按创建时间升序。
+    """
+    if keep_days is None or keep_days <= 0:
+        return []
+
+    if not os.path.isdir(base_path):
+        return []
+
+    threshold = datetime.now() - timedelta(days=keep_days)
+    candidates: list[tuple[str, datetime]] = []
+
+    for name in os.listdir(base_path):
+        full_path = os.path.join(base_path, name)
+        if not os.path.isfile(full_path):
+            continue
+        created_time = _parse_trade_log_file_created_time(full_path, name)
+        if created_time is None:
+            continue
+        if created_time < threshold:
+            candidates.append((full_path, created_time))
+
+    candidates.sort(key=lambda item: item[1])
+    return candidates
+
+
 def _rotate_trade_logs(base_path: str, keep_days: int) -> list[str]:
     """根据保留天数删除指定目录下的旧 trade/risk 日志文件。
 
@@ -252,58 +319,19 @@ def _rotate_trade_logs(base_path: str, keep_days: int) -> list[str]:
     风控日志通常使用 ``*.risk.log`` 命名（一般不含时间戳）。
     若解析失败，则退回使用文件修改时间近似作为创建时间。
     """
-    from qteasy import QT_CONFIG  # 局部导入以避免循环引用
-
     if keep_days is None or keep_days <= 0:
         return []
 
-    if not os.path.isdir(base_path):
-        return []
-
-    threshold = datetime.now() - timedelta(days=keep_days)
+    candidates = _collect_expired_trade_log_files(base_path, keep_days)
     removed_files: list[str] = []
-
-    for name in os.listdir(base_path):
-        full_path = os.path.join(base_path, name)
-        if not os.path.isfile(full_path):
-            continue
-        is_trade_csv = (
-            name.endswith('.csv')
-            and (name.startswith('trade_log_') or name.startswith('trade_summary_') or name.startswith('value_curve_'))
-        )
-        is_risk_log = name.endswith('.risk.log')
-        if not (is_trade_csv or is_risk_log):
-            continue
-
-        created_time: Optional[datetime] = None
-
+    for full_path, _created_time in candidates:
         try:
-            if is_trade_csv:
-                # 解析文件名中的时间戳部分：{prefix}_{operator_name}_%Y%m%d_%H%M%S.csv
-                stem = name[:-4]  # 去除 .csv
-                parts = stem.split('_')
-                if len(parts) >= 3:
-                    date_str, time_str = parts[-2], parts[-1]
-                    created_time = datetime.strptime(f'{date_str}_{time_str}', '%Y%m%d_%H%M%S')
-        except Exception:
-            created_time = None
-
-        if created_time is None:
-            # 解析失败时退回到 mtime
-            try:
-                created_time = datetime.fromtimestamp(os.path.getmtime(full_path))
-            except Exception:
-                continue
-
-        if created_time < threshold:
-            try:
-                os.remove(full_path)
-                removed_files.append(full_path)
-            except Exception as e:
-                # 仅记录 warning，不中断程序
-                logging.getLogger('core').warning(
-                    'Failed to remove old trade log file "%s": %s', full_path, e
-                )
+            os.remove(full_path)
+            removed_files.append(full_path)
+        except Exception as e:
+            logging.getLogger('core').warning(
+                'Failed to remove old trade log file "%s": %s', full_path, e
+            )
 
     if removed_files:
         logging.getLogger('core').info(

--- a/qteasy/__init__.py
+++ b/qteasy/__init__.py
@@ -113,15 +113,15 @@ from qteasy._arg_validators import (
 
 
 # qteasy版本信息
-__version__ = '2.5.1'
+__version__ = '2.5.2'
 version_info = Namespace(
         major=2,
         minor=5,
-        patch=1,
+        patch=2,
         short=(2, 5),
-        full=(2, 5, 1),
-        string='2.5.1',
-        tuple=('2', '5', '1'),
+        full=(2, 5, 2),
+        string='2.5.2',
+        tuple=('2', '5', '2'),
         releaselevel='beta',
 )
 

--- a/qteasy/_arg_validators.py
+++ b/qteasy/_arg_validators.py
@@ -158,6 +158,7 @@ def _valid_qt_kwargs():
                                                                                      'simple',
                                                                                      'random',  # to be deprecated
                                                                                      'manual',
+                                                                                     'xtquant',
                                                                                      ],
              'level':     1,
              'text':      '实盘交易账户的交易代理商类型，可以设置为模拟交易代理商返回交易结果、'

--- a/qteasy/broker.py
+++ b/qteasy/broker.py
@@ -43,24 +43,43 @@ _SIMULATOR_SUBMIT_REJECT_REASONS: tuple[str, ...] = (
 
 
 def _verify_trade_result(trade_result, order_qty) -> bool:
-    """ 检查result，确认是否符合基本要求:
-    包括trade_result各个组份的类型是否正确、数据是否超过范围
+    """检查 transaction yield 的成交元组是否符合基本要求。
 
-    Parameters:
-    -----------
-    trade_result: tuple: (result_type, qty, filled_price, fee)
-        result_type: str
-        qty: float
-        filled_price: float
-        fee: float
+    支持 4-tuple（内置模拟 broker）与 5-tuple（实盘券商委托号）。分段成交时
+    ``qty`` 为**本笔**成交量，须与入参 ``order_qty``（订单总量）比较。
+
+    Parameters
+    ----------
+    trade_result: tuple
+        ``(result_type, qty, filled_price, fee)`` 或
+        ``(result_type, qty, filled_price, fee, broker_order_id)``。
+        ``broker_order_id`` 为 ``str`` 或 ``None``（XtQuant 等实盘通道）。
     order_qty: float
-        订单的报价数量
+        订单申报总量，非本笔成交量。
 
     Returns
     -------
-    bool: 当result符合基本要求的时候，返回True
+    bool
+        校验通过时返回 ``True``。
     """
-    result_type, qty, filled_price, fee = trade_result
+    if not isinstance(trade_result, tuple):
+        raise TypeError(
+            f'trade_result must be a tuple, got {type(trade_result).__name__}'
+        )
+    if len(trade_result) not in (4, 5):
+        raise ValueError(
+            'trade_result must be a 4-tuple '
+            '(result_type, qty, filled_price, fee) or a 5-tuple with '
+            'broker_order_id as the fifth element, '
+            f'got length {len(trade_result)}'
+        )
+    result_type, qty, filled_price, fee = trade_result[:4]
+    broker_order_id = trade_result[4] if len(trade_result) == 5 else None
+
+    if broker_order_id is not None and not isinstance(broker_order_id, str):
+        raise TypeError(
+            f'broker_order_id should be str or None, but got {type(broker_order_id)}'
+        )
 
     if not isinstance(result_type, str):
         raise TypeError(f'result_type should be str, but got {type(result_type)}')
@@ -332,7 +351,7 @@ class Broker(object):
         self._submitted_order_map[broker_order_id] = order_dict
 
         order_type, symbol, order_qty, order_price, direction, position = self._parse_order(order_dict)
-        for result_type, filled_qty, filled_price, fee in self.transaction(
+        for trade_result in self.transaction(
                 symbol=symbol,
                 order_qty=order_qty,
                 order_price=order_price,
@@ -340,7 +359,13 @@ class Broker(object):
                 position=position,
                 order_type=order_type,
         ):
-            _verify_trade_result((result_type, filled_qty, filled_price, fee), order_qty)
+            _verify_trade_result(trade_result, order_qty)
+            if len(trade_result) == 5:
+                result_type, filled_qty, filled_price, fee, real_broker_order_id = trade_result
+            else:
+                result_type, filled_qty, filled_price, fee = trade_result
+                real_broker_order_id = None
+            result_broker_order_id = real_broker_order_id or broker_order_id
             current_datetime = get_current_timezone_datetime(self.time_zone)
             normalized_qty = round(float(filled_qty), AMOUNT_DECIMAL_PLACES)
             normalized_price = round(float(filled_price), CASH_DECIMAL_PLACES)
@@ -355,7 +380,7 @@ class Broker(object):
                 'canceled_qty':    normalized_qty if result_type == 'canceled' else 0.0,
                 'delivery_amount': 0.0,
                 'delivery_status': 'ND',
-                'broker_order_id': broker_order_id,
+                'broker_order_id': result_broker_order_id,
                 'status':          result_type,
                 'raw_status':      result_type,
             }
@@ -630,34 +655,39 @@ class Broker(object):
         """
 
         validate_trade_order(dict(order), context='Broker._get_result.order')
-        order_type, symbol, qty, price, direction, position = self._parse_order(order)
+        order_type, symbol, order_qty, price, direction, position = self._parse_order(order)
         for trade_result in self.transaction(
                 order_type=order_type,
                 symbol=symbol,
-                order_qty=qty,
+                order_qty=order_qty,
                 order_price=price,
                 direction=direction,
                 position=position
         ):
-            result_type, qty, filled_price, fee = trade_result
-            _verify_trade_result(trade_result, qty)
+            _verify_trade_result(trade_result, order_qty)
+            if len(trade_result) == 5:
+                result_type, filled_qty_this, filled_price, fee, broker_order_id = trade_result
+            else:
+                result_type, filled_qty_this, filled_price, fee = trade_result
+                broker_order_id = None
 
             # 确认数据格式正确后，将数据圆整到合适的精度，并组装为raw_trade_result
             if self.debug:
-                self.send_message(f'method: _get_result(): got transaction result for order(ID) {order["order_id"]}\n'
-                                  f'result_type={result_type}, \nqty={qty}, \n'
-                                  f'filled_price={filled_price}, \nfee={fee}')
-            # 圆整qty、filled_qty和fee
-            qty = round(qty, AMOUNT_DECIMAL_PLACES)
+                self.send_message(
+                    f'method: _get_result(): got transaction result for order(ID) {order["order_id"]}\n'
+                    f'result_type={result_type}, \nfilled_qty_this={filled_qty_this}, \n'
+                    f'filled_price={filled_price}, \nfee={fee}'
+                )
+            filled_qty_this = round(filled_qty_this, AMOUNT_DECIMAL_PLACES)
             filled_price = round(filled_price, CASH_DECIMAL_PLACES)
             transaction_fee = round(fee, CASH_DECIMAL_PLACES)
 
             filled_qty = 0
             canceled_qty = 0
             if result_type in ['filled', 'partial-filled']:
-                filled_qty = qty
+                filled_qty = filled_qty_this
             elif result_type == 'canceled':
-                canceled_qty = qty
+                canceled_qty = filled_qty_this
             else:
                 raise ValueError(f'Unknown result_type: {result_type}, should be one of ["filled", "canceled"]')
 
@@ -672,6 +702,8 @@ class Broker(object):
                 'delivery_amount': 0,
                 'delivery_status': 'ND',
             }
+            if broker_order_id:
+                raw_trade_result['broker_order_id'] = broker_order_id
 
             validate_raw_trade_result(raw_trade_result, context='Broker._get_result.raw_trade_result')
 
@@ -707,18 +739,23 @@ class Broker(object):
 
         Returns / Yields:
         -----------------
-        tuple: (result_type, qty, price, fee)
+        tuple
+            4-tuple ``(result_type, qty, price, fee)`` 或 5-tuple 在末尾附加
+            ``broker_order_id``（``str`` 或 ``None``）。内置模拟 broker 可仅 yield
+            4-tuple；XtQuant 等实盘适配器应 yield 5-tuple 并携带券商真实委托号。
+
             result_type: str 交易结果类型:
                 'filled' - 成交,
-                'partial_filled' - 部分成交,
+                'partial-filled' - 部分成交,
                 'canceled' - 取消
-                'failed' - 失败
             qty: float
-                成交/取消数量，这个数字应该小于等于order_qty，且大于等于0
+                本笔成交/取消数量，须 ``0 < qty <= order_qty``（相对订单总量）
             price: float
-                成交价格, 如果是取消交易，价格为0或任意数字
+                成交价格, 取消时须为 0
             fee: float
-                交易费用，交易费用应该大于等于0
+                交易费用，须 ``>= 0``
+            broker_order_id: str or None, optional
+                券商侧委托号；实盘通道建议在每笔回报中提供
 
         Notes:
         ------

--- a/qteasy/live_config.py
+++ b/qteasy/live_config.py
@@ -19,7 +19,9 @@ from qteasy.configure import ConfigDict
 from qteasy.utilfuncs import str_to_list
 
 # 与 _arg_validators 中 live_trade / live_price 相关校验语义对齐
-_ALLOWED_LIVE_TRADE_BROKER_TYPES = frozenset({'simulator', 'simple', 'manual', 'random'})
+_ALLOWED_LIVE_TRADE_BROKER_TYPES = frozenset({
+    'simulator', 'simple', 'manual', 'random', 'xtquant',
+})
 _ALLOWED_LIVE_PRICE_CHANNELS = frozenset({'eastmoney', 'tushare', 'akshare'})
 _ALLOWED_REFILL_CHANNELS = frozenset({'eastmoney', 'tushare', 'akshare'})
 _ALLOWED_LIVE_PRICE_FREQ = frozenset({'H', '30MIN', '15MIN', '5MIN', '1MIN', 'TICK'})

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -2231,38 +2231,38 @@ class Trader(object):
             return pd.DataFrame()
 
     def read_sys_log(self, row_count: int = None, include_debug: bool = True) -> list:
-        """ 从系统log文件中读取文本信息，保存在一个列表中，如果指定row_count = N，则读取倒数N行
+        """从系统 log 文件读取逻辑日志条目列表。
+
+        先将物理行合并为逻辑条目（多行 ``send_message`` 续行与首行同属一条），
+        再按 ``include_debug`` 过滤，最后按 ``row_count`` 取尾部若干条逻辑记录。
 
         Parameters
         ----------
         row_count: int, optional
-            如果给出row_count，则只读取倒数row_count行文本，如果为None，读取所有文本
+            若给出且大于 0，返回合并与过滤后的倒数 ``row_count`` 条逻辑记录；
+            若为 None 或小于等于 0，返回全部逻辑记录（不过滤条数上限）。
         include_debug: bool, optional, default True
-            为 False 时过滤 DEBUG 级别及带 ``<DEBUG>`` 前缀的日志行
+            为 False 时过滤 DEBUG 级别及带 ``<DEBUG>`` 前缀的日志条目。
 
         Returns
         -------
-        sys_logs: list of str
-            逐行读取的系统log文本
+        list of str
+            逻辑日志条目，每条可含换行符。
         """
 
         log_file_path = sys_log_file_path_name(self.account_id, self.datasource)
         if not os.path.exists(log_file_path):
             return []
         with open(log_file_path, 'r') as f:
-            # read last row_count lines from f
-            lines = f.readlines()
+            physical_lines = f.readlines()
 
-            if row_count is None:
-                row_count = len(lines)
-
-            if row_count > 0:
-                lines = lines[-row_count:]
-
-        lines = group_sys_log_physical_lines(lines)
+        lines = group_sys_log_physical_lines(physical_lines)
 
         if not include_debug:
             lines = [line for line in lines if not _is_debug_sys_log_line(line)]
+
+        if row_count is not None and row_count > 0:
+            lines = lines[-row_count:]
 
         return lines
 

--- a/qteasy/trader.py
+++ b/qteasy/trader.py
@@ -1787,8 +1787,11 @@ class Trader(object):
         positions = get_account_positions(self.account_id, data_source=self._datasource)
         order_details = orders.join(positions, on='pos_id', rsuffix='_p')
         order_details.drop(columns=['pos_id', 'account_id', 'qty_p', 'available_qty'], inplace=True)
+        order_details['order_id'] = order_details.index.astype(int)
+        if 'broker_order_id' not in order_details.columns:
+            order_details['broker_order_id'] = None
         order_details = order_details.reindex(
-                columns=['symbol', 'position', 'direction', 'order_type',
+                columns=['order_id', 'broker_order_id', 'symbol', 'position', 'direction', 'order_type',
                          'qty', 'price',
                          'submitted_time', 'status']
         )
@@ -1797,7 +1800,7 @@ class Trader(object):
         results = read_trade_results_by_order_id(orders.index.to_list(), data_source=self._datasource)
         order_result_details = order_details.join(results.set_index('order_id'), lsuffix='_quoted', rsuffix='_filled')
         order_result_details = order_result_details.reindex(
-                columns=['symbol', 'position', 'direction', 'order_type',
+                columns=['order_id', 'broker_order_id', 'symbol', 'position', 'direction', 'order_type',
                          'qty', 'price_quoted', 'submitted_time', 'status',
                          'price_filled', 'filled_qty', 'canceled_qty', 'transaction_fee', 'execution_time',
                          'delivery_status'],

--- a/qteasy/trader_cli.py
+++ b/qteasy/trader_cli.py
@@ -24,13 +24,14 @@ from threading import Thread
 import numpy as np
 import pandas as pd
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from cmd import Cmd
 from rich.console import Console
 from rich.text import Text
 
 from qteasy.trader import (
     TraderMessage,
+    TaskSpec,
     coerce_trader_message,
     drain_trader_message_queue,
     group_sys_log_physical_lines,
@@ -62,6 +63,7 @@ CLI_COMMAND_ALIASES = {
     'startup-gate': 'gate',
     'snapshot-reconcile': 'reconcile',
     'rotate-logs': 'rotatelogs',
+    'rotatelog': 'rotatelogs',
     'pull-state': 'sync',
 }
 
@@ -128,6 +130,103 @@ def _filter_sys_log_lines(lines: List[str], include_debug: bool = True) -> List[
     if include_debug:
         return grouped
     return [line for line in grouped if not _is_debug_sys_log_line(line)]
+
+
+def _format_bool_markup(value: bool) -> str:
+    """将布尔值格式化为带 Rich 颜色的字符串（用户可见英文 True/False）。"""
+    if value:
+        return '[bold green]True[/bold green]'
+    return '[bold red]False[/bold red]'
+
+
+def _format_scalar_for_display(value: Any, *, list_preview: int = 5) -> str:
+    """将标量/简单容器格式化为 CLI 可读字符串。"""
+    if value is None:
+        return '--'
+    if isinstance(value, bool):
+        return _format_bool_markup(value)
+    if isinstance(value, float):
+        if np.isnan(value):
+            return '--'
+        return f'{value:,.4f}'.rstrip('0').rstrip('.')
+    if isinstance(value, (list, tuple)):
+        items = list(value)
+        if not items:
+            return '[]'
+        preview = items[:list_preview]
+        text = ', '.join(str(item) for item in preview)
+        if len(items) > list_preview:
+            text += f', ...({len(items)} total)'
+        return text
+    if isinstance(value, dict):
+        if not value:
+            return '{}'
+        parts = [f'{k}={v}' for k, v in list(value.items())[:list_preview]]
+        text = ', '.join(parts)
+        if len(value) > list_preview:
+            text += f', ...({len(value)} keys)'
+        return text
+    return str(value)
+
+
+def _print_key_value_section(title: str, items: Dict[str, Any], *, width: Optional[int] = None) -> None:
+    """以 overview 风格打印键值分段（支持 Rich 颜色 markup）。"""
+    if width is None:
+        width = _terminal_width()
+    semi_width = int(width * 0.75)
+    info_str = f'{{" {title} ":=^{width}}}\n'
+    for key, value in items.items():
+        formatted = _format_scalar_for_display(value)
+        info_str += f'{key:<{semi_width - 20}}{formatted}\n'
+    rich.print(info_str, end='')
+
+
+def _normalize_task_status_filter(status: Optional[str]) -> Optional[str]:
+    """归一化 task 列表命令的状态过滤参数。"""
+    if status is None:
+        return None
+    normalized = str(status).strip().lower()
+    if normalized in ('', 'all', 'a'):
+        return None
+    if normalized in ('queued', 'q', 'in-queue', 'in_queue', 'in queue'):
+        return 'queued'
+    return str(status).strip()
+
+
+def format_trader_tasks_table(tasks: List[TaskSpec], *, rich_form: bool = True) -> str:
+    """将 Trader 任务列表格式化为与 schedule 类似的表格字符串。
+
+    Parameters
+    ----------
+    tasks : list of TaskSpec
+        待展示任务列表。
+    rich_form : bool, optional
+        是否替换方括号以避免 Rich 误解析。
+
+    Returns
+    -------
+    str
+        表格字符串；无任务时返回提示语。
+    """
+    if not tasks:
+        return 'No trader tasks found.'
+
+    rows = []
+    for task_spec in tasks:
+        rows.append({
+            'task_id': task_spec.task_id,
+            'name': task_spec.name,
+            'status': task_spec.status,
+            'retry': f'{task_spec.retry_count}/{task_spec.max_retries}',
+            'args': str(task_spec.args),
+            'canceled': task_spec.canceled,
+        })
+    task_df = pd.DataFrame(rows).set_index('task_id')
+    table_string = task_df.to_string()
+    if rich_form:
+        table_string = table_string.replace('[', '<')
+        table_string = table_string.replace(']', '>')
+    return table_string
 
 
 def _drain_message_queue(trader) -> List[TraderMessage]:
@@ -659,7 +758,7 @@ class TraderShell(Cmd):
         'tasks':      dict(prog='tasks', description='List Trader task queue entries (implemented)',
                            usage='tasks [-h] [--status STATUS] [--name NAME]'),
         'task':       dict(prog='task', description='Show or cancel a Trader queue task (implemented)',
-                           usage='task TASK_ID [-h] [--cancel]'),
+                           usage='task [TASK_ID] [-h] [--list] [--status STATUS] [--cancel]'),
         'gate':       dict(prog='gate', description='Run startup gate manually for smoke/debug (implemented)',
                            usage='gate [-h]'),
         'reconcile':  dict(prog='reconcile',
@@ -667,7 +766,7 @@ class TraderShell(Cmd):
                            usage='reconcile [-h]'),
         'rotatelogs': dict(prog='rotatelogs',
                            description='Rotate trade/risk logs under QT_TRADE_LOG_PATH (implemented)',
-                           usage='rotatelogs [-h] [--days DAYS]'),
+                           usage='rotatelogs [-h] [--days DAYS] [--yes]'),
         'broker':     dict(prog='broker',
                            description='Run broker session subcommands (implemented)',
                            usage=f'broker {{{",".join(BROKER_SUBCOMMANDS)}}} [-h]'),
@@ -741,10 +840,13 @@ class TraderShell(Cmd):
         'tasks':      [('--status', '-s'),
                        ('--name', '-n')],
         'task':       [('task_id',),
+                       ('--list', '-l'),
+                       ('--status', '-s'),
                        ('--cancel', '-c')],
         'gate':       [],
         'reconcile':  [],
-        'rotatelogs': [('--days', '-d')],
+        'rotatelogs': [('--days', '-d'),
+                       ('--yes', '-y')],
         'broker':     [('action',)],
         'sync':       [],
     }
@@ -932,7 +1034,14 @@ class TraderShell(Cmd):
                         'default': '',
                         'help':    'filter by task name (e.g. refill, run_strategy)'}],
         'task':       [{'action':  'store',
+                        'nargs':   '?',
+                        'default': None,
                         'help':    'task id to show or cancel'},
+                       {'action': 'store_true',
+                        'help':   'list trader tasks (default status: queued)'},
+                       {'action':  'store',
+                        'default': 'queued',
+                        'help':    'filter by task status when listing (e.g. queued, all, running)'},
                        {'action': 'store_true',
                         'help':   'cancel Trader queue task (not broker order; use cancel ORDER_ID for orders)'}],
         'gate':       [],
@@ -940,7 +1049,9 @@ class TraderShell(Cmd):
         'rotatelogs': [{'action':  'store',
                         'type':    int,
                         'default': None,
-                        'help':    'keep days override; default from trade_log_keep_days'}],
+                        'help':    'keep days override; default from trade_log_keep_days'},
+                       {'action': 'store_true',
+                        'help':   'confirm rotation without interactive prompt'}],
         'broker':     [{'action':  'store',
                         'choices': list(BROKER_SUBCOMMANDS),
                         'help':    'broker subcommand (Simulator connect is session flag only)'}],
@@ -1271,6 +1382,16 @@ class TraderShell(Cmd):
         """将字典以 JSON 格式打印到 stdout（用户可见英文键值）。"""
         import json
         print(json.dumps(payload, indent=indent, ensure_ascii=False, default=str))
+
+    def _print_trader_tasks_list(self,
+                                 *,
+                                 status: Optional[str] = None,
+                                 name: Optional[str] = None) -> None:
+        """打印 Trader 任务列表表格（与 schedule 风格一致）。"""
+        normalized_status = _normalize_task_status_filter(status)
+        tasks = self.trader.list_tasks(status=normalized_status, name=name or None)
+        print('Trader Tasks:')
+        print(format_trader_tasks_table(tasks))
 
     def check_buy_sell_args(self, args, type) -> bool:
         """ 检查买卖参数是否合法
@@ -2159,8 +2280,9 @@ class TraderShell(Cmd):
                 print(f'Wrong symbol is given: {symbol}, please input full symbol code like "000651" or "000651.SZ"')
                 return False
 
-        # remove rows whose value in column 'filled_qty' is 0, and sort by 'filled_time'
-        history = history[history['filled_qty'] != 0]
+        # remove rows without actual fills; NaN filled_qty must not pass through
+        filled_qty = history['filled_qty'].fillna(0)
+        history = history[(filled_qty > 0) & history['execution_time'].notna()]
         history.sort_values(by='execution_time', inplace=True)
         # change the quantity to negative if it is a sell-out
         history['filled_qty'] = np.where(history['direction'] == 'sell',
@@ -2284,17 +2406,22 @@ class TraderShell(Cmd):
             names = get_symbol_names(datasource=self.trader.datasource, symbols=symbols)
             order_details['name'] = names
             display_df = order_details.copy()
-            for col in ['price_filled', 'filled_qty', 'canceled_qty', 'delivery_status']:
-                display_df[col] = display_df[col].apply(lambda x: '--' if pd.isna(x) else x)
+            for col in ['broker_order_id', 'price_filled', 'filled_qty', 'canceled_qty', 'delivery_status']:
+                display_df[col] = display_df[col].apply(
+                        lambda x: '--' if (pd.isna(x) or x == '' or x is None) else x
+                )
             rich.print(display_df.to_string(
                     index=False,
-                    columns=['execution_time', 'symbol', 'position', 'direction', 'qty', 'price_quoted',
+                    columns=['order_id', 'broker_order_id', 'execution_time', 'symbol', 'position', 'direction',
+                             'qty', 'price_quoted',
                              'submitted_time', 'status', 'price_filled', 'filled_qty', 'canceled_qty',
                              'delivery_status', 'name'],
-                    header=['time', 'symbol', 'pos', 'buy/sell', 'qty', 'price',
+                    header=['id', 'broker_id', 'time', 'symbol', 'pos', 'buy/sell', 'qty', 'price',
                             'submitted', 'status', 'fill_price', 'fill_qty', 'canceled',
                             'delivery', 'name'],
                     formatters={'name':           '{:s}'.format,
+                                'order_id':       '{:d}'.format,
+                                'broker_order_id': lambda x: x if x == '--' else f'{x}',
                                 'qty':            '{:,.2f}'.format,
                                 'price_quoted':   '¥{:,.2f}'.format,
                                 'price_filled':   lambda x: x if x == '--' else f'¥{float(x):,.2f}',
@@ -2781,17 +2908,36 @@ class TraderShell(Cmd):
 
         cfg = build_live_trade_config(self.trader.get_config())
         summary = dict(cfg.to_summary_dict())
+        broker_items = {
+            'Broker Type': summary.pop('broker_type'),
+            'Broker Params': summary.pop('live_trade_broker_params'),
+        }
+        market_items = {
+            'Live Price Channel': summary.pop('live_price_channel'),
+            'Live Price Freq': summary.pop('live_price_freq'),
+            'Asset Type': summary.pop('asset_type'),
+            'Time Zone': summary.pop('time_zone'),
+            'UI Type': summary.pop('live_trade_ui_type'),
+        }
+        account_items = {
+            'Account ID': summary.pop('live_trade_account_id'),
+            'Asset Pool': summary.pop('asset_pool'),
+            'Benchmark Asset': summary.pop('benchmark_asset'),
+        }
+        _print_key_value_section('Live Trade Config - Broker', broker_items)
+        _print_key_value_section('Live Trade Config - Market', market_items)
+        _print_key_value_section('Live Trade Config - Account', account_items)
         if args.detail:
-            summary.update({
-                'live_trade_startup_gate_mode': cfg.live_trade_startup_gate_mode,
-                'live_trade_split_strategy_prepare': cfg.live_trade_split_strategy_prepare,
-                'live_trade_strategy_snapshot_max_age_seconds': cfg.live_trade_strategy_snapshot_max_age_seconds,
-                'live_trade_prepare_lead_seconds': cfg.live_trade_prepare_lead_seconds,
-                'live_trade_data_refill_channel': cfg.live_trade_data_refill_channel,
-                'live_trade_data_refill_batch_size': cfg.live_trade_data_refill_batch_size,
-                'live_trade_data_refill_batch_interval': cfg.live_trade_data_refill_batch_interval,
-            })
-        self._print_json(summary)
+            detail_items = {
+                'Startup Gate Mode': cfg.live_trade_startup_gate_mode,
+                'Split Strategy Prepare': cfg.live_trade_split_strategy_prepare,
+                'Strategy Snapshot Max Age (s)': cfg.live_trade_strategy_snapshot_max_age_seconds,
+                'Prepare Lead Seconds': cfg.live_trade_prepare_lead_seconds,
+                'Data Refill Channel': cfg.live_trade_data_refill_channel,
+                'Data Refill Batch Size': cfg.live_trade_data_refill_batch_size,
+                'Data Refill Batch Interval': cfg.live_trade_data_refill_batch_interval,
+            }
+            _print_key_value_section('Live Trade Config - Extended', detail_items)
         return None
 
     def do_tasks(self, arg):
@@ -2812,25 +2958,21 @@ class TraderShell(Cmd):
 
         status = args.status or None
         name = args.name or None
-        tasks = self.trader.list_tasks(status=status, name=name)
-        print(f'Trader tasks: {len(tasks)}')
-        for task_spec in tasks:
-            print(
-                f'  {task_spec.task_id}  name={task_spec.name}  status={task_spec.status}  '
-                f'retry={task_spec.retry_count}/{task_spec.max_retries}'
-            )
+        self._print_trader_tasks_list(status=status, name=name)
         return None
 
     def do_task(self, arg):
-        """usage: task TASK_ID [-h] [--cancel]
+        """usage: task [TASK_ID] [-h] [--list] [--status STATUS] [--cancel]
 
-        Show or cancel one Trader queue task (implemented). Use cancel ORDER_ID for broker orders.
+        Show, list, or cancel Trader queue tasks (implemented). Use cancel ORDER_ID for broker orders.
 
         positional arguments:
           task_id               task id to show or cancel
 
         optional arguments:
           -h, --help            show this help message and exit
+          --list, -l            list trader tasks (default status filter: queued)
+          --status, -s STATUS   filter by task status when listing (e.g. queued, all, running)
           --cancel, -c          cancel the queue task instead of showing details
         """
 
@@ -2838,9 +2980,20 @@ class TraderShell(Cmd):
         if not args:
             return False
 
+        if args.list and args.cancel:
+            print('Cannot use --list and --cancel together.')
+            return False
+
+        if args.list:
+            if args.task_id:
+                print('Cannot combine --list with a task id; use "task TASK_ID" to show one task.')
+                return False
+            self._print_trader_tasks_list(status=args.status)
+            return None
+
         task_id = args.task_id
         if not task_id:
-            print('Please provide a task id.')
+            print('Please provide a task id, or use --list to show queued tasks.')
             return False
 
         if args.cancel:
@@ -2886,7 +3039,10 @@ class TraderShell(Cmd):
 
         allowed = self.trader.run_startup_gate()
         mode = str(qt.QT_CONFIG.get('live_trade_startup_gate_mode', 'off'))
-        print(f'Startup gate result: allowed={allowed} (mode={mode})')
+        _print_key_value_section('Startup Gate', {
+            'Mode': mode,
+            'Allowed': allowed,
+        })
         return None
 
     def do_reconcile(self, arg):
@@ -2905,7 +3061,30 @@ class TraderShell(Cmd):
             return False
 
         snapshot = self.trader.collect_broker_reconcile_snapshot()
-        self._print_json(snapshot)
+        tolerance = snapshot.get('tolerance')
+        cash_diff = snapshot.get('cash_diff')
+        position_qty_diff = snapshot.get('position_qty_diff')
+        failures = snapshot.get('failures') or []
+        cash_diff_text = _format_scalar_for_display(cash_diff)
+        if cash_diff is not None and tolerance is not None and abs(float(cash_diff)) > float(tolerance):
+            cash_diff_text = f'[bold red]{cash_diff_text}[/bold red]'
+        position_diff_text = _format_scalar_for_display(position_qty_diff)
+        if position_qty_diff is not None and tolerance is not None and abs(float(position_qty_diff)) > float(tolerance):
+            position_diff_text = f'[bold red]{position_diff_text}[/bold red]'
+        _print_key_value_section('Broker Reconcile', {
+            'Overall OK': snapshot.get('is_ok'),
+            'Tolerance': tolerance,
+            'Remote Cash': snapshot.get('remote_cash'),
+            'Local Cash Total': snapshot.get('local_cash_total'),
+            'Cash Diff': cash_diff_text,
+            'Remote Position Qty Total': snapshot.get('remote_position_qty_total'),
+            'Local Position Qty Total': snapshot.get('local_position_qty_total'),
+            'Position Qty Diff': position_diff_text,
+            'Remote Orders Count': snapshot.get('remote_orders_count'),
+            'Remote Positions Count': snapshot.get('remote_positions_count'),
+            'Primary History Table': snapshot.get('primary_history_table'),
+            'Failures': ', '.join(failures) if failures else '(none)',
+        })
         return None
 
     def do_rotatelogs(self, arg):
@@ -2924,6 +3103,7 @@ class TraderShell(Cmd):
             return False
 
         import qteasy as qt
+        from datetime import datetime, timedelta
 
         if args.days is None:
             keep_days = qt.QT_CONFIG.get('trade_log_keep_days', 3)
@@ -2935,8 +3115,35 @@ class TraderShell(Cmd):
             return None
 
         log_path = qt.QT_TRADE_LOG_PATH
-        qt.rotate_trade_logs(days=args.days)
-        print(f'Trade log rotation completed (keep_days={keep_days}, path={log_path})')
+        candidates = qt._collect_expired_trade_log_files(log_path, int(keep_days))
+        cutoff = datetime.now() - timedelta(days=int(keep_days))
+        print(f'Trade log rotation preview (keep_days={keep_days}, path={log_path})')
+        print(f'Cutoff time: {cutoff:%Y-%m-%d %H:%M:%S}')
+        if not candidates:
+            print('No expired trade/risk log files to remove.')
+            return None
+
+        print(f'Will remove {len(candidates)} file(s):')
+        preview_limit = 20
+        for full_path, created_time in candidates[:preview_limit]:
+            print(f'  {full_path}  (created {created_time:%Y-%m-%d %H:%M:%S})')
+        if len(candidates) > preview_limit:
+            print(f'  ... and {len(candidates) - preview_limit} more')
+
+        confirmed = bool(args.yes)
+        if not confirmed:
+            if not _is_tty_stream(sys.stdin):
+                print('Rotation aborted (non-interactive). Use --yes to confirm.')
+                return None
+            answer = input('Continue? [y/N]: ').strip().lower()
+            confirmed = answer in ('y', 'yes')
+
+        if not confirmed:
+            print('Rotation canceled.')
+            return None
+
+        removed = qt._rotate_trade_logs(log_path, int(keep_days))
+        print(f'Trade log rotation completed (removed={len(removed)}, keep_days={keep_days}, path={log_path})')
         return None
 
     def do_broker(self, arg):
@@ -2964,10 +3171,12 @@ class TraderShell(Cmd):
         broker = self.trader.broker
         action = args.action
         if action == 'status':
-            print(
-                f'broker_name={broker.broker_name} status={broker.status} '
-                f'is_connected={broker.is_connected} is_registered={broker.is_registered}'
-            )
+            _print_key_value_section('Broker Status', {
+                'Broker Name': broker.broker_name,
+                'Status': broker.status,
+                'Connected': broker.is_connected,
+                'Registered': broker.is_registered,
+            })
         elif action == 'connect':
             broker.connect()
             print('Broker connected.')

--- a/qteasy/trader_cli.py
+++ b/qteasy/trader_cli.py
@@ -736,7 +736,7 @@ class TraderShell(Cmd):
         'dashboard':  dict(prog='', description='Exit shell and enter dashboard',
                            usage='dashboard [-h] [--rewind REWIND]',
                            epilog='Exit shell and enter dashboard mode, where trading logs '
-                                  'are displayed in real time, provide an integer to rewind '
+                                  'are displayed in real time; provide an integer to rewind '
                                   'previous rows of logs, default 50 rows'),
         'strategies': dict(prog='', description='Show or change strategy parameters',
                            usage='strategies [STRATEGY [STRATEGY ...]] [-h] [--detail] '
@@ -985,7 +985,7 @@ class TraderShell(Cmd):
         'dashboard':  [{'action':  'store',
                         'type':    int,
                         'default': 50,
-                        'help':    'rewind previous rows of logs, default to 50'}],
+                        'help':    'rewind previous log entries (logical records), default 50'}],
         'strategies': [{'action': 'append',  # TODO: for python version >= 3.8, use action='extend' instead
                         'nargs':  '*',  # nargs='+' will require at least one argument
                         'help':   'strategy to show or change parameters for'},
@@ -1121,7 +1121,7 @@ class TraderShell(Cmd):
         self._dashboard_on_status_line = True
 
     def _replay_dashboard_logs(self, rewind: int) -> None:
-        """排空消息队列并按当前 ``debug`` 设置回放系统日志尾部若干行。
+        """排空消息队列并按当前 ``debug`` 设置回放系统日志尾部若干条逻辑记录。
 
         ``send_message`` 会先写入系统日志再放入队列；此处排空队列不做打印，
         仅回放日志尾部，避免与 ``read_sys_log`` 同一内容重复输出。
@@ -1129,7 +1129,7 @@ class TraderShell(Cmd):
         Parameters
         ----------
         rewind : int
-            系统日志回卷行数，与 ``dashboard -r`` 一致。
+            逻辑日志条数上限，与 ``dashboard -r`` 一致（非文件物理行数）。
 
         Returns
         -------
@@ -2579,13 +2579,13 @@ class TraderShell(Cmd):
         optional arguments:
           -h, --help    show this help message and exit
           --rewind REWIND, -r REWIND
-                        number of lines to rewind  (default: 50)
+                        number of logical log entries to rewind (default: 50)
 
         Examples:
         ---------
         to enter dashboard mode:
         (QTEASY) dashboard
-        to enter dashboard mode and rewind 100 lines:
+        to enter dashboard mode and rewind 100 log entries:
         (QTEASY) dashboard -r 100
         """
 
@@ -2593,7 +2593,7 @@ class TraderShell(Cmd):
         if not args:
             return False
         if args.rewind < 0 or args.rewind > 999:
-            print('can not rewind more than 999 lines or less than 0 lines. please check your input.')
+            print('can not rewind more than 999 log entries or less than 0. please check your input.')
             return False
 
         import os

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -137,6 +137,35 @@ class TestBroker(unittest.TestCase):
 
     def test_verify_trade_result(self):
         """ test the function _verify_trade_result """
+        print('\n[TestBroker.test_verify_trade_result] 4/5-tuple 校验')
+        order_qty = 100.0
+        four = ('filled', 50.0, 10.5, 1.0)
+        five = ('partial-filled', 25.0, 10.5, 0.5, '109000001')
+        print(' valid 4-tuple:', four)
+        print(' valid 5-tuple:', five)
+        self.assertTrue(_verify_trade_result(four, order_qty))
+        self.assertTrue(_verify_trade_result(five, order_qty))
+
+        with self.assertRaises(ValueError) as cm:
+            _verify_trade_result(('filled', 50.0, 10.5), order_qty)
+        print(' bad length msg:', cm.exception)
+        self.assertIn('4-tuple', str(cm.exception))
+
+        with self.assertRaises(TypeError):
+            _verify_trade_result(
+                ('filled', 50.0, 10.5, 1.0, 12345),
+                order_qty,
+            )
+
+        with self.assertRaises(ValueError):
+            _verify_trade_result(('filled', 150.0, 10.5, 1.0), order_qty)
+
+        with self.assertRaises(ValueError) as cm_cancel:
+            _verify_trade_result(('canceled', 10.0, 5.0, 0.0), order_qty)
+        print(' canceled non-zero price msg:', cm_cancel.exception)
+        self.assertIn('filled_price', str(cm_cancel.exception))
+
+        self.assertTrue(_verify_trade_result(('canceled', 10.0, 0.0, 0.0), order_qty))
 
     def test_parse_order(self):
         """ test the function parse_order """

--- a/tests/test_broker_contract.py
+++ b/tests/test_broker_contract.py
@@ -255,6 +255,23 @@ class TestBrokerContract(unittest.TestCase):
         self.assertEqual(result['transaction_fee'], 5.0)
         validate_raw_trade_result(result, context='test.legacy')
 
+    def test_get_result_partial_fills_use_order_qty_not_shadowed(self):
+        print('\n[TestBrokerContract] 分段成交 order_qty 不被循环内 qty 覆盖')
+        broker = MinimalBrokerForContractTest()
+        broker.connect()
+        order_qty = float(self.order['qty'])
+        half_qty = round(order_qty / 2, 4)
+        remain_qty = round(order_qty - half_qty, 4)
+        print(' order_qty:', order_qty, ' expected fills:', half_qty, remain_qty)
+        broker._get_result(self.order)
+        first = broker.result_queue.get()
+        second = broker.result_queue.get()
+        print(' first fill:', first)
+        print(' second fill:', second)
+        self.assertEqual(first['filled_qty'], half_qty)
+        self.assertEqual(second['filled_qty'], remain_qty)
+        self.assertTrue(broker.result_queue.empty())
+
     def test_submit_rejects_invalid_order_dict(self):
         print('\n[TestBrokerContract] submit 拒绝非法订单')
         broker = MinimalBrokerForContractTest()

--- a/tests/test_broker_order_id_persistence_20260429.py
+++ b/tests/test_broker_order_id_persistence_20260429.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+# ======================================
+# File: test_broker_order_id_persistence_20260429.py
+# Author: Jackie PENG
+# Contact: jackie.pengzhao@gmail.com
+# Created: 2026-05-21
+# Desc:
+# Regression for broker 5-tuple transaction results and broker_order_id
+# in raw_trade_result (S0-2 / PR-0a).
+# ======================================
+
+from __future__ import annotations
+
+import unittest
+
+from qteasy.broker import Broker
+
+
+_VALID_ORDER = {
+    'order_id': 101,
+    'pos_id': 6,
+    'direction': 'buy',
+    'order_type': 'market',
+    'qty': 100.0,
+    'price': 1.23,
+    'status': 'submitted',
+    'submitted_time': '2026-04-29 13:21:10',
+    'symbol': '513100.SH',
+    'position': 'long',
+}
+
+
+class _BrokerTestMixin:
+    """避免 Broker._parse_order 访问真实 DB。"""
+
+    def _parse_order(self, order):
+        return (
+            order['order_type'],
+            order.get('symbol', '513100.SH'),
+            float(order['qty']),
+            float(order['price']),
+            order['direction'],
+            order.get('position', 'long'),
+        )
+
+
+class _FiveTupleBroker(_BrokerTestMixin, Broker):
+    def __init__(self):
+        super().__init__(data_source=None)
+        self.broker_name = 'XtQuantBroker'
+        self.register(debug=False)
+        self.connect()
+
+    def transaction(self, symbol, order_qty, order_price, direction, position='long', order_type='market'):
+        yield ('filled', order_qty, order_price, 1.0, '109000001')
+
+
+class _FourTupleBroker(_BrokerTestMixin, Broker):
+    def __init__(self):
+        super().__init__(data_source=None)
+        self.broker_name = 'LegacyBroker'
+        self.register(debug=False)
+        self.connect()
+
+    def transaction(self, symbol, order_qty, order_price, direction, position='long', order_type='market'):
+        yield ('filled', order_qty, order_price, 1.0)
+
+
+class TestBrokerOrderIdPersistence20260429(unittest.TestCase):
+    def test_five_tuple_get_result_persists_broker_order_id(self):
+        print('\n[TestBrokerOrderIdPersistence] _get_result 写入 broker_order_id')
+        broker = _FiveTupleBroker()
+        broker._get_result(dict(_VALID_ORDER))
+        result = broker.result_queue.get()
+        print(' raw_trade_result:', result)
+        self.assertEqual(result['broker_order_id'], '109000001')
+        self.assertEqual(result['filled_qty'], 100.0)
+
+    def test_five_tuple_submit_poll_fills_persists_broker_order_id(self):
+        print('\n[TestBrokerOrderIdPersistence] submit -> poll_fills broker_order_id')
+        broker = _FiveTupleBroker()
+        broker.submit(dict(_VALID_ORDER))
+        fills = broker.poll_fills()
+        print(' fills:', fills)
+        self.assertEqual(len(fills), 1)
+        self.assertEqual(fills[0]['broker_order_id'], '109000001')
+
+    def test_four_tuple_legacy_broker_still_works(self):
+        print('\n[TestBrokerOrderIdPersistence] 4-tuple legacy broker 仍可用')
+        broker = _FourTupleBroker()
+        broker._get_result(dict(_VALID_ORDER))
+        result = broker.result_queue.get()
+        print(' raw_trade_result:', result)
+        self.assertEqual(result['filled_qty'], 100.0)
+        self.assertNotIn('broker_order_id', result)
+
+        broker2 = _FourTupleBroker()
+        returned_boid = broker2.submit(dict(_VALID_ORDER))
+        fills = broker2.poll_fills()
+        print(' submit returned_boid:', returned_boid, ' fills:', fills)
+        self.assertEqual(len(fills), 1)
+        self.assertEqual(fills[0]['broker_order_id'], returned_boid)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_live_config.py
+++ b/tests/test_live_config.py
@@ -16,7 +16,11 @@ import warnings
 
 from qteasy._arg_validators import ConfigDict
 from qteasy.broker import SimulatorBroker
-from qteasy.live_config import LiveTradeConfig, build_live_trade_config
+from qteasy.live_config import (
+    LiveTradeConfig,
+    _ALLOWED_LIVE_TRADE_BROKER_TYPES,
+    build_live_trade_config,
+)
 from qteasy.trader import Trader
 
 from tests.trader_test_helpers import (
@@ -100,7 +104,33 @@ class TestBuildLiveTradeConfig(unittest.TestCase):
         print(' broker/ui:', cfg.live_trade_broker_type, cfg.live_trade_ui_type)
         self.assertEqual(cfg.live_trade_broker_type, 'simulator')
         self.assertEqual(cfg.live_trade_ui_type, 'cli')
-        self.assertIn(cfg.live_trade_broker_type, {'simulator', 'simple', 'manual', 'random'})
+        self.assertIn(cfg.live_trade_broker_type, _ALLOWED_LIVE_TRADE_BROKER_TYPES)
+
+    def test_build_accepts_xtquant_broker_type(self) -> None:
+        print('\n[TestBuildLiveTradeConfig] A4 xtquant broker type accepted')
+        base = _minimal_valid_live_mapping()
+        base['live_trade_broker_type'] = 'xtquant'
+        cfg = build_live_trade_config(base)
+        print(' broker_type:', cfg.live_trade_broker_type)
+        self.assertEqual(cfg.live_trade_broker_type, 'xtquant')
+        self.assertIn(cfg.live_trade_broker_type, _ALLOWED_LIVE_TRADE_BROKER_TYPES)
+
+    def test_build_normalizes_xtquant_broker_type_case(self) -> None:
+        print('\n[TestBuildLiveTradeConfig] A5 XtQuant -> xtquant normalization')
+        base = _minimal_valid_live_mapping()
+        base['live_trade_broker_type'] = 'XtQuant'
+        cfg = build_live_trade_config(base)
+        print(' broker_type:', cfg.live_trade_broker_type)
+        self.assertEqual(cfg.live_trade_broker_type, 'xtquant')
+
+    def test_configdict_accepts_xtquant_broker_type(self) -> None:
+        print('\n[TestBuildLiveTradeConfig] A6 ConfigDict/qt.configure validator accepts xtquant')
+        mapping = _minimal_valid_live_mapping()
+        mapping['live_trade_broker_type'] = 'xtquant'
+        cd = ConfigDict(mapping)
+        print(' ConfigDict broker_type:', cd['live_trade_broker_type'])
+        cfg = build_live_trade_config(cd)
+        self.assertEqual(cfg.live_trade_broker_type, 'xtquant')
 
     def test_build_accepts_random_broker_with_deprecation_warning(self) -> None:
         print('\n[TestBuildLiveTradeConfig] A3 random broker FutureWarning')

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -1076,10 +1076,13 @@ class TestTrader(unittest.TestCase):
         # test history orders without results
         history_orders = ts.history_orders(with_trade_results=False)
         self.assertIsInstance(ts.history_orders(), pd.DataFrame)
-        self.assertEqual(history_orders.shape, (9, 8))
-        self.assertEqual(history_orders.columns.tolist(), ['symbol', 'position', 'direction', 'order_type',
+        self.assertEqual(history_orders.shape, (9, 10))
+        self.assertEqual(history_orders.columns.tolist(), ['order_id', 'broker_order_id', 'symbol', 'position',
+                                                           'direction', 'order_type',
                                                            'qty', 'price',
                                                            'submitted_time', 'status'])
+        print(' history_orders columns:', history_orders.columns.tolist())
+        self.assertTrue(history_orders['order_id'].between(1, 9).all())
         # test manual change of cashes and positions
         self.assertEqual(ts.account_cash, (73905.0, 73905.0, 100000.0))
         ts.manual_change_cash(10000.0)
@@ -2223,7 +2226,7 @@ class TestTraderAccountOrders(unittest.TestCase):
     def test_history_orders_without_results_columns(self):
         ho = self.trader.history_orders(with_trade_results=False)
         self.assertIsInstance(ho, pd.DataFrame)
-        for col in ['symbol', 'position', 'direction', 'qty', 'price', 'status']:
+        for col in ['order_id', 'broker_order_id', 'symbol', 'position', 'direction', 'qty', 'price', 'status']:
             self.assertIn(col, ho.columns)
 
     def test_history_orders_with_results_columns(self):

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -2520,6 +2520,56 @@ class TestTraderInfoAndMessages(unittest.TestCase):
         if os.path.exists(path):
             os.remove(path)
 
+    def test_read_sys_log_row_count_returns_n_logical_non_debug_entries(self):
+        """row_count 在过滤 DEBUG 后仍返回 N 条逻辑 INFO 记录（非物理行截断）。"""
+        print('\n[TestTraderInfoAndMessages] read_sys_log row_count after debug filter')
+        from qteasy.trading_util import sys_log_file_path_name
+
+        path = sys_log_file_path_name(self.trader.account_id, self.trader.datasource)
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, 'w', encoding='utf-8') as f:
+            for i in range(40):
+                f.write(f'INFO: replay_info_{i:02d}\n')
+            for i in range(40):
+                f.write(f'DEBUG: replay_debug_{i:02d}\n')
+
+        filtered = self.trader.read_sys_log(row_count=20, include_debug=False)
+        print(' filtered count:', len(filtered))
+        print(' filtered tail:', filtered)
+        self.assertEqual(len(filtered), 20)
+        for line in filtered:
+            self.assertIn('replay_info_', line)
+            self.assertNotIn('replay_debug_', line)
+        self.assertIn('replay_info_39', filtered[-1])
+        self.assertIn('replay_info_20', filtered[0])
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_read_sys_log_row_count_one_returns_last_non_debug_entry(self):
+        """row_count=1 在过滤 DEBUG 后返回最后一条非 DEBUG 逻辑记录。"""
+        print('\n[TestTraderInfoAndMessages] read_sys_log row_count=1 last non-debug entry')
+        from qteasy.trading_util import sys_log_file_path_name
+
+        path = sys_log_file_path_name(self.trader.account_id, self.trader.datasource)
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('<DEBUG><May18 14:55:10>running: generated trade signals:\n')
+            f.write('symbols: []\n')
+            f.write('positions: []\n')
+            f.write('<May18 14:55:10>running: strategy done.\n')
+            f.write('INFO: trailing_info_record\n')
+
+        filtered = self.trader.read_sys_log(row_count=1, include_debug=False)
+        print(' filtered:', filtered)
+        self.assertEqual(len(filtered), 1)
+        self.assertIn('trailing_info_record', filtered[0])
+        combined = ''.join(filtered)
+        self.assertNotIn('symbols: []', combined)
+        if os.path.exists(path):
+            os.remove(path)
+
 
 class TestTraderBoundaries(unittest.TestCase):
     """Boundary and edge cases: empty account, cost_params None, read_sys_log row_count edge, etc."""

--- a/tests/test_trader_cli.py
+++ b/tests/test_trader_cli.py
@@ -49,6 +49,8 @@ from qteasy.trader_cli import (
     _parse_error_recovery_choice,
     _read_line_with_timeout,
     _read_line_with_timeout_unix,
+    _normalize_task_status_filter,
+    format_trader_tasks_table,
 )
 from qteasy.trading_util import (
     process_account_delivery,
@@ -1299,16 +1301,16 @@ class TestTraderCLI(unittest.TestCase):
         print('\n[TestCommandLiveconfig] help returns False')
         self.assertFalse(tss.do_liveconfig('-h'))
 
-        print('[TestCommandLiveconfig] summary JSON keys')
+        print('[TestCommandLiveconfig] human-readable summary')
         buf = io.StringIO()
         with redirect_stdout(buf):
             self.assertIsNone(tss.do_liveconfig(''))
-        summary = json.loads(buf.getvalue())
-        print(' summary:', summary)
-        self.assertIn('broker_type', summary)
-        self.assertIn('asset_pool', summary)
-        self.assertIn('live_trade_account_id', summary)
-        self.assertEqual(summary['broker_type'], 'simulator')
+        out = buf.getvalue()
+        print(' summary output:', out)
+        self.assertIn('Live Trade Config - Broker', out)
+        self.assertIn('Broker Type', out)
+        self.assertIn('simulator', out)
+        self.assertNotIn('"broker_type"', out)
 
         print('[TestCommandLiveconfig] live-config alias via precmd')
         self.assertEqual(tss.precmd('live-config --detail'), 'liveconfig --detail')
@@ -1316,21 +1318,23 @@ class TestTraderCLI(unittest.TestCase):
         buf = io.StringIO()
         with redirect_stdout(buf):
             self.assertIsNone(tss.do_liveconfig('--detail'))
-        detail = json.loads(buf.getvalue())
-        print(' detail keys:', sorted(detail.keys()))
-        self.assertIn('live_trade_startup_gate_mode', detail)
+        detail_out = buf.getvalue()
+        print(' detail output:', detail_out)
+        self.assertIn('Live Trade Config - Extended', detail_out)
+        self.assertIn('Startup Gate Mode', detail_out)
 
     def test_command_tasks(self):
         """test tasks list and task show/cancel"""
         tss = self.tss
 
-        print('\n[TestCommandTasks] empty queue')
+        print('\n[TestCommandTasks] empty queue table')
         buf = io.StringIO()
         with redirect_stdout(buf):
             self.assertIsNone(tss.do_tasks(''))
         out = buf.getvalue()
         print(' tasks output:', out)
-        self.assertIn('Trader tasks: 0', out)
+        self.assertIn('Trader Tasks:', out)
+        self.assertIn('No trader tasks found.', out)
 
         print('[TestCommandTasks] add task then list/show/cancel')
         task_id = tss.trader.add_task('refill', 'stock_daily')
@@ -1340,9 +1344,10 @@ class TestTraderCLI(unittest.TestCase):
             self.assertIsNone(tss.do_tasks(''))
         out = buf.getvalue()
         print(' tasks after add:', out)
-        self.assertIn('Trader tasks: 1', out)
+        self.assertIn('Trader Tasks:', out)
         self.assertIn(task_id, out)
-        self.assertIn('name=refill', out)
+        self.assertIn('refill', out)
+        self.assertIn('status', out)
 
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -1375,7 +1380,9 @@ class TestTraderCLI(unittest.TestCase):
                 self.assertIsNone(tss.do_gate(''))
             out = buf.getvalue()
             print(' gate allowed output:', out)
-            self.assertIn('allowed=True', out)
+            self.assertIn('Startup Gate', out)
+            self.assertIn('Allowed', out)
+            self.assertIn('True', out)
 
         with patch.object(tss.trader, 'run_startup_gate', return_value=False):
             buf = io.StringIO()
@@ -1383,7 +1390,8 @@ class TestTraderCLI(unittest.TestCase):
                 self.assertIsNone(tss.do_gate(''))
             out = buf.getvalue()
             print(' gate blocked output:', out)
-            self.assertIn('allowed=False', out)
+            self.assertIn('Startup Gate', out)
+            self.assertIn('False', out)
 
         print('[TestCommandGate] startup-gate alias via precmd')
         self.assertEqual(tss.precmd('startup-gate'), 'gate')
@@ -1399,13 +1407,12 @@ class TestTraderCLI(unittest.TestCase):
         buf = io.StringIO()
         with redirect_stdout(buf):
             self.assertIsNone(tss.do_reconcile(''))
-        snapshot = json.loads(buf.getvalue())
-        print(' reconcile snapshot:', snapshot)
-        self.assertIn('is_ok', snapshot)
-        self.assertIn('failures', snapshot)
-        self.assertIn('remote_orders_count', snapshot)
-        self.assertIsInstance(snapshot['is_ok'], bool)
-        self.assertIsInstance(snapshot['failures'], list)
+        out = buf.getvalue()
+        print(' reconcile output:', out)
+        self.assertIn('Broker Reconcile', out)
+        self.assertIn('Overall OK', out)
+        self.assertIn('Remote Orders Count', out)
+        self.assertNotIn('"is_ok"', out)
 
         print('[TestCommandReconcile] snapshot-reconcile alias via precmd')
         self.assertEqual(tss.precmd('snapshot-reconcile'), 'reconcile')
@@ -1418,6 +1425,7 @@ class TestTraderCLI(unittest.TestCase):
         self.assertEqual(CLI_COMMAND_ALIASES.get('startup-gate'), 'gate')
         self.assertEqual(CLI_COMMAND_ALIASES.get('snapshot-reconcile'), 'reconcile')
         self.assertEqual(CLI_COMMAND_ALIASES.get('rotate-logs'), 'rotatelogs')
+        self.assertEqual(CLI_COMMAND_ALIASES.get('rotatelog'), 'rotatelogs')
         self.assertEqual(CLI_COMMAND_ALIASES.get('pull-state'), 'sync')
         self.assertEqual(len(DEBUG_RUN_TASK_CHOICES), 7)
 
@@ -1450,11 +1458,12 @@ class TestTraderCLI(unittest.TestCase):
             qt.QT_TRADE_LOG_PATH = tmp_dir
             buf = io.StringIO()
             with redirect_stdout(buf):
-                self.assertIsNone(tss.do_rotatelogs('--days 30'))
+                self.assertIsNone(tss.do_rotatelogs('--days 30 --yes'))
             out = buf.getvalue()
             print(' rotatelogs output:', out)
             print(' files after rotation:', sorted(os.listdir(tmp_dir)))
             self.assertIn('Trade log rotation completed', out)
+            self.assertIn('removed=1', out)
             self.assertIn(tmp_dir, out)
             self.assertFalse(os.path.exists(old_path))
             self.assertTrue(os.path.exists(recent_path))
@@ -1477,7 +1486,9 @@ class TestTraderCLI(unittest.TestCase):
             self.assertIsNone(tss.do_broker('status'))
         status_out = buf.getvalue()
         print(' status output:', status_out)
-        self.assertIn('is_connected=False', status_out)
+        self.assertIn('Broker Status', status_out)
+        self.assertIn('Connected', status_out)
+        self.assertIn('False', status_out)
 
         print('[TestCommandBroker] connect then status')
         buf = io.StringIO()
@@ -1491,7 +1502,8 @@ class TestTraderCLI(unittest.TestCase):
             self.assertIsNone(tss.do_broker('status'))
         status_out = buf.getvalue()
         print(' status after connect:', status_out)
-        self.assertIn('is_connected=True', status_out)
+        self.assertIn('Broker Status', status_out)
+        self.assertIn('True', status_out)
 
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -1501,6 +1513,188 @@ class TestTraderCLI(unittest.TestCase):
 
         print(' BROKER_SUBCOMMANDS:', BROKER_SUBCOMMANDS)
         self.assertFalse(tss.do_broker(''))
+
+    def test_orders_shows_order_ids(self):
+        """orders 输出应包含 order_id 与 broker_order_id 列。"""
+        tss = self.tss
+        print('\n[TestOrdersShowsOrderIds] orders table includes id columns')
+
+        order_ids = save_parsed_trade_orders(
+                account_id=1,
+                symbols=['000001.SZ'],
+                positions=['long'],
+                directions=['buy'],
+                quantities=[100],
+                prices=[10.0],
+                data_source=tss.trader.datasource,
+        )
+        order_id = order_ids[0]
+        submit_order(order_id, tss.trader.datasource)
+        detail = read_trade_order_detail(order_id=order_id, data_source=tss.trader.datasource)
+        print(' order detail:', detail)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIsNone(tss.do_orders('--status submitted'))
+        out = buf.getvalue()
+        print(' orders output:\n', out)
+        self.assertIn('id', out)
+        self.assertIn('broker_id', out)
+        self.assertIn(str(order_id), out)
+
+    def test_history_excludes_unfilled_and_canceled(self):
+        """history 应过滤无成交与已取消订单，仅保留 filled_qty>0 的记录。"""
+        tss = self.tss
+        test_ds = tss.trader.datasource
+        print('\n[TestHistoryExcludesUnfilled] filter canceled/unfilled rows')
+
+        filled_order_ids = save_parsed_trade_orders(
+                account_id=1,
+                symbols=['000001.SZ'],
+                positions=['long'],
+                directions=['buy'],
+                quantities=[100],
+                prices=[10.0],
+                data_source=test_ds,
+        )
+        filled_order_id = filled_order_ids[0]
+        submit_order(filled_order_id, test_ds)
+        process_trade_result(
+                raw_trade_result={
+                    'order_id': filled_order_id,
+                    'filled_qty': 100,
+                    'price': 10.5,
+                    'transaction_fee': 5.0,
+                    'canceled_qty': 0.0,
+                },
+                data_source=test_ds,
+        )
+
+        canceled_order_ids = save_parsed_trade_orders(
+                account_id=1,
+                symbols=['000002.SZ'],
+                positions=['long'],
+                directions=['buy'],
+                quantities=[100],
+                prices=[11.0],
+                data_source=test_ds,
+        )
+        canceled_order_id = canceled_order_ids[0]
+        submit_order(canceled_order_id, test_ds)
+        tss.do_cancel(str(canceled_order_id))
+
+        history_df = tss.trader.history_orders()
+        print(' history_orders:\n', history_df[['order_id', 'symbol', 'status', 'filled_qty', 'execution_time']])
+        filled_rows = history_df[
+            (history_df['filled_qty'].fillna(0) > 0) & history_df['execution_time'].notna()
+        ]
+        canceled_rows = history_df[history_df['order_id'] == canceled_order_id]
+        print(' filled_rows count:', len(filled_rows), ' canceled row filled_qty:', canceled_rows['filled_qty'].tolist())
+        self.assertEqual(len(filled_rows), 1)
+        self.assertTrue(pd.isna(canceled_rows.iloc[0]['filled_qty']) or canceled_rows.iloc[0]['filled_qty'] == 0)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIsNone(tss.do_history(''))
+        out = buf.getvalue()
+        print(' history output:\n', out)
+        self.assertIn('000001.SZ', out)
+        self.assertNotIn('000002.SZ', out)
+        self.assertEqual(out.count('000001.SZ'), 1)
+
+    def test_task_list_default_queued_and_all(self):
+        """task -l 默认仅 queued；task -l -s all 与 tasks 等价。"""
+        tss = self.tss
+        print('\n[TestTaskList] default queued filter and all listing')
+
+        queued_id = tss.trader.add_task('refill', 'stock_daily')
+        done_spec = tss.trader._new_task_spec('pre_open', ())
+        done_spec.status = 'done'
+        tss.trader._task_registry[done_spec.task_id] = done_spec
+        print(' queued_id:', queued_id, ' done_id:', done_spec.task_id)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIsNone(tss.do_task('--list'))
+        queued_out = buf.getvalue()
+        print(' task -l output:', queued_out)
+        self.assertIn(queued_id, queued_out)
+        self.assertNotIn(done_spec.task_id, queued_out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIsNone(tss.do_task('--list --status all'))
+        all_task_out = buf.getvalue()
+        print(' task -l -s all output:', all_task_out)
+        self.assertIn(queued_id, all_task_out)
+        self.assertIn(done_spec.task_id, all_task_out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIsNone(tss.do_tasks(''))
+        tasks_out = buf.getvalue()
+        print(' tasks output:', tasks_out)
+        self.assertIn(queued_id, tasks_out)
+        self.assertIn(done_spec.task_id, tasks_out)
+
+        print(' normalize in-queue alias:', _normalize_task_status_filter('in queue'))
+        self.assertEqual(_normalize_task_status_filter('in queue'), 'queued')
+
+    def test_tasks_table_format_helper(self):
+        """format_trader_tasks_table 输出 schedule 风格表格。"""
+        print('\n[TestTasksTableFormat] helper table columns')
+        task_spec = self.tss.trader._new_task_spec('refill', ('stock_daily',))
+        table = format_trader_tasks_table([task_spec])
+        print(' table:\n', table)
+        self.assertIn('task_id', table)
+        self.assertIn('name', table)
+        self.assertIn('status', table)
+        self.assertIn(task_spec.task_id, table)
+
+    def test_rotatelogs_preview_and_confirm(self):
+        """rotatelogs 预览、非 TTY 中止、--yes 执行删除。"""
+        tss = self.tss
+        print('\n[TestRotatelogsConfirm] preview/confirm/--yes behavior')
+
+        tmp_dir = tempfile.mkdtemp()
+        original_path = qt.QT_TRADE_LOG_PATH
+        try:
+            old_path = os.path.join(tmp_dir, 'old_account.risk.log')
+            with open(old_path, 'w', encoding='utf-8') as f:
+                f.write('old-risk\n')
+            old_time = time.time() - 40 * 24 * 3600
+            os.utime(old_path, (old_time, old_time))
+            qt.QT_TRADE_LOG_PATH = tmp_dir
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertIsNone(tss.do_rotatelogs('--days 30'))
+            aborted_out = buf.getvalue()
+            print(' non-interactive output:', aborted_out)
+            self.assertIn('Rotation aborted (non-interactive)', aborted_out)
+            self.assertTrue(os.path.exists(old_path))
+
+            with patch('builtins.input', return_value='n'):
+                with patch('qteasy.trader_cli._is_tty_stream', return_value=True):
+                    buf = io.StringIO()
+                    with redirect_stdout(buf):
+                        self.assertIsNone(tss.do_rotatelogs('--days 30'))
+            canceled_out = buf.getvalue()
+            print(' user declined output:', canceled_out)
+            self.assertIn('Rotation canceled', canceled_out)
+            self.assertTrue(os.path.exists(old_path))
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertIsNone(tss.do_rotatelogs('--days 30 --yes'))
+            yes_out = buf.getvalue()
+            print(' --yes output:', yes_out)
+            self.assertIn('Trade log rotation completed', yes_out)
+            self.assertFalse(os.path.exists(old_path))
+        finally:
+            qt.QT_TRADE_LOG_PATH = original_path
+            if os.path.isdir(tmp_dir):
+                shutil.rmtree(tmp_dir, ignore_errors=True)
 
     def test_command_sync_stub(self):
         """test sync stub and pull-state alias"""

--- a/tests/test_trader_cli.py
+++ b/tests/test_trader_cli.py
@@ -1896,6 +1896,36 @@ class TestTraderCLIDashboardDisplay(unittest.TestCase):
         finally:
             clear_tables(test_ds)
 
+    def test_replay_dashboard_logs_returns_requested_entry_count(self):
+        """``_replay_dashboard_logs(N)`` 在 debug=False 时回放 N 条非 DEBUG 逻辑记录。"""
+        from tests.trader_test_helpers import create_trader_with_account, clear_tables
+
+        print('\n[TestTraderCLIDashboardDisplay] replay returns N non-debug entries')
+        trader, test_ds = create_trader_with_account(debug=False, legacy=True)
+        try:
+            _detach_live_logger_handlers()
+            log_path = sys_log_file_path_name(trader.account_id, test_ds)
+            with open(log_path, 'w', encoding='utf-8') as f:
+                for i in range(30):
+                    f.write(f'INFO: cli_replay_info_{i:02d}\n')
+                for i in range(30):
+                    f.write(f'DEBUG: cli_replay_debug_{i:02d}\n')
+            shell = TraderShell(trader)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                shell._replay_dashboard_logs(20)
+            out = buf.getvalue()
+            print(' replay line count in stdout:', out.count('\n'))
+            info_hits = sum(out.count(f'cli_replay_info_{i:02d}') for i in range(30))
+            debug_hits = sum(out.count(f'cli_replay_debug_{i:02d}') for i in range(30))
+            print(' info_hits:', info_hits, ' debug_hits:', debug_hits)
+            self.assertEqual(info_hits, 20)
+            self.assertEqual(debug_hits, 0)
+            self.assertIn('cli_replay_info_29', out)
+            self.assertIn('cli_replay_info_10', out)
+        finally:
+            clear_tables(test_ds)
+
     def test_print_status_line_pads_to_width(self):
         """状态行按终端宽度用空格填充并以 ``\\r`` 结尾。"""
         tss = TraderShell.__new__(TraderShell)


### PR DESCRIPTION
## Summary

将 `qt_2.5_dev` 合并至 `master`，发布 **2.5.2**（PATCH）。本 PR 聚焦三方面：

1. **Live Trader Shell CLI 易用性** — 订单/任务/运维命令更易读、更易操作  
2. **Dashboard 系统日志回放** — `-r` 回放条数与设定一致（逻辑日志条目）  
3. **XtQuant / MiniQMT 协作基础（PR-0a/0b）** — 5 元组成交回报、`xtquant` 配置白名单与英文适配契约  

全量 `unittest discover` 已在本地通过。

## Version

- **2.5.1 → 2.5.2**（`pyproject.toml`、`qteasy.__init__.py`、`meta.yaml`、README/docs 版本引用）  
- 用户向变更见 [`docs/source/RELEASE_HISTORY.md`](docs/source/RELEASE_HISTORY.md) §2.5.2  

## Changes

### Live Trader CLI

| 区域 | 变更 |
|------|------|
| `orders` | 表格增加 `id`（本地 `order_id`）、`broker_id`（`broker_order_id`） |
| `history` | 仅显示确有成交的记录（修复 `filled_qty` NaN 与无成交订单混入） |
| `task` / `tasks` | `task -l` 列出任务（默认 `queued`）；`tasks` 与 `schedule` 同风格表格 |
| `broker` / `gate` / `reconcile` / `liveconfig` | 分段键值可读输出 + 布尔绿/红着色（不再输出 JSON） |
| `rotatelogs` | 删除前预览文件列表；TTY 确认；非 TTY 须 `--yes`；别名 `rotatelog` |

### Dashboard 日志回放

- `Trader.read_sys_log()`：先全文件 **逻辑分组** → 可选过滤 DEBUG → 再取尾部 N 条  
- `dashboard -r` 语义为 **逻辑日志条数**（默认 50），非物理行数  
- 修复非 DEBUG 模式下回放条数明显少于 `-r` 的问题  

### 数据 API

- `Trader.history_orders()` 返回列增加 `order_id`、`broker_order_id`（CLI `orders` 与测试已对齐）

### Broker / XtQuant（协作方对接）

- `transaction()` 支持 **4/5 元组** 回报（第 5 项 `broker_order_id`）  
- 修复分段成交校验误用本笔成交量作为订单总量的问题  
- `live_trade_broker_type='xtquant'` 配置合法化（需扩展包 `register()` 后才能真正接入）  
- 新增文档：[`docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md`](docs/source/live_trading/4a-xtquant-broker-adapter-contract-v1.md)  

### 其他

- `qteasy/__init__.py`：抽取 `_collect_expired_trade_log_files()`，供 `rotatelogs` 预览与删除复用  

## Test plan

- [x] 全量 `python -m unittest discover -s tests`（维护者本地）  
- [x] `tests.test_trader_cli` — CLI 命令、dashboard 回放条数  
- [x] `tests.test_trader` — `read_sys_log`、`history_orders` 列（含 `test_trader_properties_methods`）  
- [x] `tests.test_broker*` / `test_broker_order_id_persistence_*` — 5 元组与 `broker_order_id` 持久化  

## Notes for reviewers

- **`history_orders` 列变更**：返回 DataFrame 由 8/16 列扩展为含 `order_id`、`broker_order_id`；依赖固定列数的脚本需更新（仓库内测试已改）。  
- **`read_sys_log(row_count=N)` 语义**：N 为逻辑条目数；非物理行数。  
- **`rotatelogs` 非交互行为**：管道/CI 下须显式 `--yes` 才会删除（更安全）。  
- **XtQuant**：本 PR 为契约与配置白名单；不含完整 QMT 适配器实现。  

## Post-merge

- [ ] 打 tag `v2.5.2`（与 `meta.yaml` `git_rev` 一致）  
- [ ] PyPI / 文档站发布按项目流程  